### PR TITLE
[SCL-111] Update sdk to have relay intercept feature

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -10,8 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     env:
       ENVIRONMENT_API_KEY: ${{ secrets.ENVIRONMENT_API_KEY }}
-      EV_API_URL: https://api.evervault.io
-      EV_CAGE_RUN_URL: https://run.evervault.io
+      EV_API_HOST: api.evervault.io
+      EV_CAGE_RUN_HOST: run.evervault.io
+      EV_RELAY_HOST: strict.relay.evervault.io
     steps:
       - uses: actions/checkout@v2
       - name: install dependencies

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -19,7 +19,7 @@ jobs:
       - name: build project
         run: gradle clean build
       - name: unit tests
-        run: ./gradlew test
+        run: ./gradlew test --info
       - name: Upload unit test report on failure
         if: ${{ failure() }}
         uses: actions/upload-artifact@v2

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -31,7 +31,7 @@ jobs:
           ENVIRONMENT_API_KEY: ${{ secrets.ENVIRONMENT_API_KEY }}
           EV_API_URL: https://api.evervault.io
           EV_CAGE_RUN_URL: https://run.evervault.io
-        run: ./gradlew integrationTests
+        run: ./gradlew integrationTests --info
       - name: Upload integration test report on failure
         if: ${{ failure() }}
         uses: actions/upload-artifact@v2

--- a/README.md
+++ b/README.md
@@ -2,7 +2,17 @@
 
 # Evervault Java SDK
 
-The [Evervault](https://evervault.com) Java SDK is a toolkit for encrypting data as it enters your server, and working with Cages. 
+The [Evervault](https://evervault.com) Java SDK can be used to:
+
+1. Encrypt data at your server
+2. Run your Cages
+3. Encrypt/decrypt data with Relay
+
+You can use our Java SDK to encrypt data — rather than with **[Relay](/concepts/relay/overview)** — and still send it to a third-party via Relay. Encrypting with our backend SDKs is best for developers who want to avoid the network latency of Relay and/or want to avoid sending plaintext data to Relay to be encrypted.
+
+Encrypting data with our backend SDKs instead of Relay may expose you to greater compliance burden because plaintext data touches your server before it is encrypted.
+
+You don’t need to change your database configuration. You can store Evervault-encrypted data in your database as you would the plaintext version.
 
 ## Getting Started
 
@@ -12,7 +22,7 @@ For full installation support, [book time here](https://calendly.com/evervault/c
 
 ## Documentation
 
-See the Evervault [Java SDK documentation](https://docs.evervault.com/sdk/java).
+See the Evervault [Java SDK documentation](https://docs.evervault.com/reference/java-sdk).
 
 ## Installation
 
@@ -34,9 +44,67 @@ implementation 'com.evervault:lib:2.0.1'
 
 ## Usage
 
-You have access to two main methods.
+The Evervault Java SDK exposes a constructor and two functions:
 
-Warning: this SDK does not support the outbound proxy.
+* `evervault.encrypt()`
+* `evervault.run()`
+
+### Relay Interception
+
+The Evervault Java SDK can automatically route all outbound HTTPS requests through Relay for decryption. This can be done by setting up a proxy to Evervault on your HTTP client.
+
+To disable this behaviour, set `intercept` to `false` in the initialization options. For the most common Java HTTP Clients, here is how intercept can be set up:
+
+#### Apache HTTP Client
+
+Apache HTTP Client uses two extra JVM settings to authenticate with the proxy. When the Evervault Java SDK is initialised with intercept enabled, it sets these settings.
+
+```java
+// Note This is done automatically when you setup the Evervault SDK
+
+System.setProperty("https.proxyUser", user);
+System.setProperty("https.proxyPassword", password);
+System.setProperty("http.proxyUser", user);
+System.setProperty("http.proxyPassword", password);
+```
+
+#### Java 11 Client
+
+When using the new Java 11 client, **you will have to update the client to use the default authenticator and proxy like so**:
+
+```java
+// When the Evervault Java SDK is initialised with intercept enabled, it's set's the default authenticator and proxy.
+// You just need to inject the authenticator into your builder.
+
+HttpClient httpClient = HttpClient.newBuilder()
+  .authenticator(Authenicator.getDefault())
+  ...
+  .build();
+```
+
+#### HTTPUrlConnection API
+
+When using the original HTTPUrlConnection API, you can use intercept out of the box. When you initialize the evervault Java SDK with intercept enabled (enabled by default). It sets the JVM properties for sending a request through a proxy.
+
+```java
+// Note This is done automatically when you setup the Evervault SDK
+
+System.setProperty("http.proxyHost", proxyHost);
+System.setProperty("http.proxyPort", proxyPort);
+System.setProperty("https.proxyHost", proxyHost);
+System.setProperty("https.proxyPort", proxyPort);
+```
+
+### Manual Proxy
+
+If you use a different http client to the clients above, you can setup relay interception by setting the http client to proxy requests through relay with these details:
+
+| Setting   | Value                                                                   |
+|-----------|-------------------------------------------------------------------------|
+| host      | strict.relay.evervault.com                                              |
+| port      | 8443                                                                    |
+| user      | Your Evervault Team's UUID (Can be found in the Evervault Dashboard)    |
+| password  | Your Evervault Team's API_KEY (Can be found in the Evervault Dashboard) |
 
 ### encrypt
 
@@ -52,8 +120,21 @@ run will send the data to your cage to be processed.
 
 ### constructor
 
-Evervault constructor expected your api key which you can retrieve from evervault website.
+Evervault constructor expects your api key which you can retrieve from evervault website. There are also optional parameters.
 
+```java
+var Evervault = new Evervault(API_KEY)
+```
+
+| Parameter        | Type                         | Description                                                                                                                          |
+| ---------------- | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `apiKey`         | `String`                     | The API key of your Evervault Team                                                                                                   |
+| `curve`          | `Evervault.EcdhCurve`        | The elliptic curve used for cryptographic operations. See [Elliptic Curve Support](/reference/elliptic-curve-support) to learn more. |
+| `intercept`      | `Boolean`                    | Route outbound requests through Evervault to automatically decrypt encrypted fields.                                                 |
+| `ignoreDomains`  | `String[]`                   | An array of hostnames which will not be routed through Evervault for encryption. eg [ "api.example.com", "support.example.com" ]        |
+
+
+### Example
 ```java
 private static class Bar {
     public String name;
@@ -80,3 +161,7 @@ void encryptAndRun() throws EvervaultException {
 #### 1.0.2
 
 * Evervault urls ending with slash now fixed.
+
+#### 2.0.1
+
+* Evervault Java SDK now supports intercepting requests for decryption.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Our Java SDK is distributed via [maven](https://search.maven.org/artifact/com.ev
 
 ### Gradle
 ```sh
-implementation 'com.evervault:lib:1.0.1'
+implementation 'com.evervault:lib:2.0.1'
 ```
 
 ### Maven
@@ -28,7 +28,7 @@ implementation 'com.evervault:lib:1.0.1'
 <dependency>
   <groupId>com.evervault</groupId>
   <artifactId>lib</artifactId>
-  <version>1.0.1</version>
+  <version>2.0.1</version>
 </dependency>
 ```
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ See the Evervault [Java SDK documentation](https://docs.evervault.com/reference/
 
 ## Installation
 
-Our Java SDK is distributed via [maven](https://search.maven.org/artifact/com.evervault/lib), and can be installed using your preferred built tool.
+Our Java SDK is distributed via [maven](https://search.maven.org/artifact/com.evervault/lib), and can be installed using your preferred build tool.
 
 ### Gradle
 ```sh

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -6,10 +6,11 @@ plugins {
 }
 
 group 'com.evervault'
-version '1.0.2'
+version '2.0.1'
 
 repositories {
     mavenCentral()
+    mavenLocal()
 }
 
 def getRepositoryUsername() {

--- a/lib/src/integrationTests/java/evervault/WhenUsingApiAgainstRealEnvironmentTests.java
+++ b/lib/src/integrationTests/java/evervault/WhenUsingApiAgainstRealEnvironmentTests.java
@@ -57,7 +57,7 @@ public class WhenUsingApiAgainstRealEnvironmentTests {
     void encryptSomeDataCorrectly() throws EvervaultException {
         final String someDataToEncrypt = "Foo";
 
-        var evervault = new Evervault(getEnvironmentApiKey(), false);
+        var evervault = new Evervault(getEnvironmentApiKey());
 
         var result = (String) evervault.encrypt(someDataToEncrypt);
 
@@ -83,7 +83,7 @@ public class WhenUsingApiAgainstRealEnvironmentTests {
 
     @Test
     void encryptAndRun() throws EvervaultException {
-        var evervault = new Evervault(getEnvironmentApiKey(), false);
+        var evervault = new Evervault(getEnvironmentApiKey());
 
         var cageResult = evervault.run(cageName, Bar.createFooStructure(evervault), false, null);
 
@@ -92,7 +92,7 @@ public class WhenUsingApiAgainstRealEnvironmentTests {
 
     @Test
     void encryptAndRunR1Curve() throws EvervaultException {
-        var evervault = new Evervault(getEnvironmentApiKey(), EcdhCurve.SECP256R1, false);
+        var evervault = new Evervault(getEnvironmentApiKey(), EcdhCurve.SECP256R1);
 
         var cageResult = evervault.run(cageName, Bar.createFooStructure(evervault), false, null);
 
@@ -101,7 +101,7 @@ public class WhenUsingApiAgainstRealEnvironmentTests {
 
     private static class OwnEvervault extends Evervault {
         public OwnEvervault(String apiKey) throws EvervaultException {
-            super(apiKey, false);
+            super(apiKey);
         }
 
         public byte[] getSharedKey() {

--- a/lib/src/integrationTests/java/evervault/WhenUsingApiAgainstRealEnvironmentTests.java
+++ b/lib/src/integrationTests/java/evervault/WhenUsingApiAgainstRealEnvironmentTests.java
@@ -101,7 +101,7 @@ public class WhenUsingApiAgainstRealEnvironmentTests {
 
     private static class OwnEvervault extends Evervault {
         public OwnEvervault(String apiKey) throws EvervaultException {
-            super(apiKey);
+            super(apiKey, false);
         }
 
         public byte[] getSharedKey() {

--- a/lib/src/integrationTests/java/evervault/WhenUsingApiAgainstRealEnvironmentTests.java
+++ b/lib/src/integrationTests/java/evervault/WhenUsingApiAgainstRealEnvironmentTests.java
@@ -57,7 +57,7 @@ public class WhenUsingApiAgainstRealEnvironmentTests {
     void encryptSomeDataCorrectly() throws EvervaultException {
         final String someDataToEncrypt = "Foo";
 
-        var evervault = new Evervault(getEnvironmentApiKey());
+        var evervault = new Evervault(getEnvironmentApiKey(), false);
 
         var result = (String) evervault.encrypt(someDataToEncrypt);
 
@@ -83,7 +83,7 @@ public class WhenUsingApiAgainstRealEnvironmentTests {
 
     @Test
     void encryptAndRun() throws EvervaultException {
-        var evervault = new Evervault(getEnvironmentApiKey());
+        var evervault = new Evervault(getEnvironmentApiKey(), false);
 
         var cageResult = evervault.run(cageName, Bar.createFooStructure(evervault), false, null);
 
@@ -92,7 +92,7 @@ public class WhenUsingApiAgainstRealEnvironmentTests {
 
     @Test
     void encryptAndRunR1Curve() throws EvervaultException {
-        var evervault = new Evervault(getEnvironmentApiKey(), EcdhCurve.SECP256R1);
+        var evervault = new Evervault(getEnvironmentApiKey(), EcdhCurve.SECP256R1, false);
 
         var cageResult = evervault.run(cageName, Bar.createFooStructure(evervault), false, null);
 

--- a/lib/src/main/java/evervault/Evervault.java
+++ b/lib/src/main/java/evervault/Evervault.java
@@ -7,50 +7,48 @@ import evervault.utils.EcdhCurve;
 import java.util.Objects;
 
 public class Evervault extends EvervaultService {
-    private static final String EVERVAULT_BASE_URL = "https://api.evervault.com/";
-    private static final String EVERVAULT_RUN_URL = "https://run.evervault.com/";
-    private static final String EVERVAULT_BASE_HOST = "api.evervault.com";
+    private static final String EVERVAULT_API_HOST = "api.evervault.com";
     private static final String EVERVAULT_RUN_HOST = "run.evervault.com";
     private static final String EVERVAULT_RELAY_HOST = "strict.relay.evervault.com";
 
-    private String evervaultApiUrl;
-    private String evervaultRunUrl;
-    private String evervaultRelayUrl;
+    private String evervaultApiHost;
+    private String evervaultRunHost;
+    private String evervaultRelayHost;
     private String[] evervaultIgnoreDomains;
 
-    public String getEvervaultBaseUrl() {
-        return evervaultApiUrl;
-    }
+    public String getEvervaultApiHost() { return evervaultApiHost; }
 
-    public String getEvervaultRunUrl() {
-        return evervaultRunUrl;
-    }
+    public String getEvervaultApiUrl() { return "https://" + evervaultApiHost + "/"; }
 
-    public String getEvervaultRelayUrl() {
-        return evervaultRelayUrl;
+    public String getEvervaultRunHost() { return evervaultRunHost; };
+
+    public String getEvervaultRunUrl() { return "https://" + evervaultRunHost + "/"; }
+
+    public String getEvervaultRelayHost() {
+        return evervaultRelayHost;
     }
 
     public String[] getEvervaultIgnoreDomains() {
         return evervaultIgnoreDomains;
     }
 
-    private void setEvervaultBaseUrl() {
-        var envApiUrl = System.getenv("EV_API_URL");
-        this.evervaultApiUrl = Objects.requireNonNullElse(envApiUrl, EVERVAULT_BASE_URL);
+    private void setEvervaultApiHost() {
+        var envApiHost = System.getenv("EV_API_HOST");
+        this.evervaultApiHost = Objects.requireNonNullElse(envApiHost, EVERVAULT_API_HOST);
     }
 
-    private void setEvervaultRunUrl() {
-        var envRunUrl = System.getenv("EV_CAGE_RUN_URL");
-        this.evervaultRunUrl = Objects.requireNonNullElse(envRunUrl, EVERVAULT_RUN_URL);
+    private void setEvervaultRunHost() {
+        var envRunHost = System.getenv("EV_CAGE_RUN_HOST");
+        this.evervaultRunHost = Objects.requireNonNullElse(envRunHost, EVERVAULT_RUN_HOST);
     }
 
     private void setEvervaultRelayUrl() {
-        var envRelayUrl = System.getenv("EV_RELAY_HOST");
-        this.evervaultRelayUrl = Objects.requireNonNullElse(envRelayUrl, EVERVAULT_RELAY_HOST);
+        var envRelayHost = System.getenv("EV_RELAY_HOST");
+        this.evervaultRelayHost = Objects.requireNonNullElse(envRelayHost, EVERVAULT_RELAY_HOST);
     }
 
     private void setEvervaultIgnoreDomains(String[] ignoreDomains) {
-        String[] defaultDomains = {EVERVAULT_BASE_HOST, EVERVAULT_RUN_HOST};
+        String[] defaultDomains = {getEvervaultApiHost(), getEvervaultRunHost()};
         if (ignoreDomains == null) {
             this.evervaultIgnoreDomains = defaultDomains;
         } else {
@@ -96,8 +94,8 @@ public class Evervault extends EvervaultService {
     }
 
     public Evervault(String apiKey, EcdhCurve ecdhCurve, Boolean intercept, String[] ignoreDomains) throws EvervaultException {
-        setEvervaultBaseUrl();
-        setEvervaultRunUrl();
+        setEvervaultApiHost();
+        setEvervaultRunHost();
         setEvervaultRelayUrl();
         setEvervaultIgnoreDomains(ignoreDomains);
 
@@ -115,11 +113,6 @@ public class Evervault extends EvervaultService {
 
         this.setupEncryption(encryptForObject);
 
-
-        if (intercept) {
-            System.out.println("SETTING UP INTERCEPT");
-            this.setupIntercept(apiKey);
-
-        }
+        if (intercept) { this.setupIntercept(apiKey); }
     }
 }

--- a/lib/src/main/java/evervault/Evervault.java
+++ b/lib/src/main/java/evervault/Evervault.java
@@ -7,11 +7,11 @@ import evervault.utils.EcdhCurve;
 import java.util.Objects;
 
 public class Evervault extends EvervaultService {
-    private static final String EVERVAULT_BASE_URL = "https://api.evervault.io/";
-    private static final String EVERVAULT_RUN_URL = "https://run.evervault.io/";
-    private static final String EVERVAULT_BASE_HOST = "api.evervault.io";
-    private static final String EVERVAULT_RUN_HOST = "run.evervault.io";
-    private static final String EVERVAULT_RELAY_HOST = "strict.relay.evervault.io";
+    private static final String EVERVAULT_BASE_URL = "https://api.evervault.com/";
+    private static final String EVERVAULT_RUN_URL = "https://run.evervault.com/";
+    private static final String EVERVAULT_BASE_HOST = "api.evervault.com";
+    private static final String EVERVAULT_RUN_HOST = "run.evervault.com";
+    private static final String EVERVAULT_RELAY_HOST = "strict.relay.evervault.com";
 
     private String evervaultApiUrl;
     private String evervaultRunUrl;

--- a/lib/src/main/java/evervault/Evervault.java
+++ b/lib/src/main/java/evervault/Evervault.java
@@ -114,6 +114,12 @@ public class Evervault extends EvervaultService {
         var encryptForObject = new EvervaultEncryptionService(encryptService, this.generatedEcdhKey, this.sharedKey);
 
         this.setupEncryption(encryptForObject);
-        if (intercept) this.setupIntercept(apiKey);
+
+
+        if (intercept) {
+            System.out.println("SETTING UP INTERCEPT");
+            this.setupIntercept(apiKey);
+
+        }
     }
 }

--- a/lib/src/main/java/evervault/services/EvervaultService.java
+++ b/lib/src/main/java/evervault/services/EvervaultService.java
@@ -36,7 +36,13 @@ public abstract class EvervaultService {
     protected Boolean intercept = true;
 
     // Virtual method
-    protected String getEvervaultBaseUrl() {
+    protected String getEvervaultApiHost() { return ""; }
+
+    // Virtual method
+    protected String getEvervaultApiUrl() { return ""; }
+
+    // Virtual method
+    protected String getEvervaultRunHost() {
         return "";
     }
 
@@ -46,9 +52,7 @@ public abstract class EvervaultService {
     }
 
     // Virtual method
-    protected String getEvervaultRelayUrl() {
-        return "";
-    }
+    protected String getEvervaultRelayHost() { return ""; }
 
     // Virtual method
     protected String[] getEvervaultIgnoreDomains() { return new String[0]; }
@@ -111,7 +115,7 @@ public abstract class EvervaultService {
     }
 
     private void setupKeys(EcdhCurve ecdhCurve) throws HttpFailureException, IOException, InterruptedException, NoSuchAlgorithmException, InvalidKeySpecException, InvalidAlgorithmParameterException, InvalidKeyException, NotPossibleToHandleDataTypeException, MaxRetryReachedException, NoSuchProviderException, NotImplementedException {
-        var teamEcdhKey = circuitBreakerProvider.execute(getCageHash, () -> cagePublicKeyFromEndpointProvider.getCagePublicKeyFromEndpoint(getEvervaultBaseUrl()));
+        var teamEcdhKey = circuitBreakerProvider.execute(getCageHash, () -> cagePublicKeyFromEndpointProvider.getCagePublicKeyFromEndpoint(getEvervaultApiUrl()));
 
         teamUuid = teamEcdhKey.teamUuid;
 
@@ -128,7 +132,7 @@ public abstract class EvervaultService {
 
         String user = teamUuid;
         String password = apiKey;
-        String proxyHost = getEvervaultRelayUrl();
+        String proxyHost = getEvervaultRelayHost();
         String proxyPort = RELAY_PORT;
         String ignoreDomains = String.join("|", getEvervaultIgnoreDomains());
 

--- a/lib/src/main/java/evervault/services/HttpHandler.java
+++ b/lib/src/main/java/evervault/services/HttpHandler.java
@@ -8,6 +8,7 @@ import evervault.models.CageRunResult;
 import com.google.gson.Gson;
 
 import java.io.IOException;
+import java.net.Authenticator;
 import java.net.URI;
 import java.net.http.HttpRequest;
 import java.net.http.HttpRequest.BodyPublishers;

--- a/lib/src/main/java/evervault/services/ProxyAuthenticator.java
+++ b/lib/src/main/java/evervault/services/ProxyAuthenticator.java
@@ -1,0 +1,18 @@
+package evervault.services;
+
+import java.net.Authenticator;
+import java.net.PasswordAuthentication;
+
+public class ProxyAuthenticator extends Authenticator {
+
+    private final String user, password;
+
+    public ProxyAuthenticator(String user, String password) {
+        this.user = user;
+        this.password = password;
+    }
+
+    protected PasswordAuthentication getPasswordAuthentication() {
+        return new PasswordAuthentication(user, password.toCharArray());
+    }
+}


### PR DESCRIPTION
# Why

Need to be able to enable relay intercept through the Java SDK. 

# How

Added features to enable relay interception when initialising the Evervault Java SDK

### Commit Messages

We use [semantic-release](https://github.com/semantic-release/semantic-release#how-does-it-work) for deployments. If one of your commits should be deployed, ensure the commit message is in the format corresponding to the correct release type. This can also be done in a squash commit.

Note: breaking changes should always use the `BREAKING CHANGE:` commit message format.

TODO:
- [x] Update SDK readme
- [x] Update Docs