### PR TITLE
v2.0.4 - Fix issue with intercept and Java 11 Http Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Our Java SDK is distributed via [maven](https://search.maven.org/artifact/com.ev
 
 ### Gradle
 ```sh
-implementation 'com.evervault:lib:2.0.3'
+implementation 'com.evervault:lib:2.0.4'
 ```
 
 ### Maven
@@ -38,7 +38,7 @@ implementation 'com.evervault:lib:2.0.3'
 <dependency>
   <groupId>com.evervault</groupId>
   <artifactId>lib</artifactId>
-  <version>2.0.3</version>
+  <version>2.0.4</version>
 </dependency>
 ```
 
@@ -182,3 +182,7 @@ void encryptAndRun() throws EvervaultException {
 ### 2.0.3
 
 * Move to new package name structure
+
+### 2.0.4
+
+* Fix issue with Java 11 Http Client and proxy

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group 'com.evervault'
-version '2.0.3'
+version '2.0.4'
 
 repositories {
     mavenCentral()

--- a/lib/src/main/java/com/evervault/services/EvervaultService.java
+++ b/lib/src/main/java/com/evervault/services/EvervaultService.java
@@ -135,6 +135,9 @@ public abstract class EvervaultService {
         String proxyPort = RELAY_PORT;
         String ignoreDomains = String.join("|", getEvervaultIgnoreDomains());
 
+        System.setProperty("jdk.https.auth.tunneling.disabledSchemes", "");
+        System.setProperty("jdk.http.auth.tunneling.disabledSchemes", "");
+
         Authenticator authenticator = new ProxyAuthenticator(user, password);
         Authenticator.setDefault(authenticator);
 
@@ -143,14 +146,12 @@ public abstract class EvervaultService {
         System.setProperty("https.proxyUser", user);
         System.setProperty("https.proxyPassword", password);
         System.setProperty("https.nonProxyHosts", ignoreDomains);
-        System.setProperty("jdk.https.auth.tunneling.disabledSchemes", "");
-
+        
         System.setProperty("http.proxyHost", proxyHost);
         System.setProperty("http.proxyPort", proxyPort);
         System.setProperty("http.proxyUser", user);
         System.setProperty("http.proxyPassword", password);
         System.setProperty("http.nonProxyHosts", ignoreDomains);
-        System.setProperty("jdk.http.auth.tunneling.disabledSchemes", "");
     }
 
     private void generateSharedKey() throws InvalidAlgorithmParameterException, NoSuchAlgorithmException, InvalidKeyException, NotImplementedException {


### PR DESCRIPTION
# Why

The setting for tunnelling has to be defined before the proxy is set up it seems

# How

Tested out with the client and had to define this before the evervault SDK was created to get it to work.

```System.setProperty("jdk.https.auth.tunneling.disabledSchemes", "");```

### Commit Messages

We use [semantic-release](https://github.com/semantic-release/semantic-release#how-does-it-work) for deployments. If one of your commits should be deployed, ensure the commit message is in the format corresponding to the correct release type. This can also be done in a squash commit.

Note: breaking changes should always use the `BREAKING CHANGE:` commit message format.
