### PR TITLE
Add string for allowing basic Auth to system settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,11 +79,18 @@ System.setProperty("http.proxyPassword", password);
 
 #### Java 11 Client
 
-When using the new Java 11 client, **you will have to update the client to use the default authenticator and proxy like so**:
+When using the new Java 11 client, you will have to: 
+
+* Add a system property before the SDK is initiased to enable BASIC auth with the proxy.
+* Update HTTP Client to use the default Authenticator (The default is set by the SDK).
 
 ```java
-// When the Evervault Java SDK is initialised with intercept enabled, it's set's the default authenticator and proxy.
-// You just need to inject the authenticator into your builder.
+
+import com.evervault.Evervault;
+import com.evervault.utils.ProxySystemSettings;
+
+System.setProperty(ProxySystemSettings.PROXY_DISABLED_SCHEMES_KEY, ProxySystemSettings.PROXY_DISABLED_SCHEMES_VALUE);
+var evervault = new Evervault(apiKey);
 
 HttpClient httpClient = HttpClient.newBuilder()
   .authenticator(Authenicator.getDefault())

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Our Java SDK is distributed via [maven](https://search.maven.org/artifact/com.ev
 
 ### Gradle
 ```sh
-implementation 'com.evervault:lib:2.0.4'
+implementation 'com.evervault:lib:2.0.5'
 ```
 
 ### Maven
@@ -38,7 +38,7 @@ implementation 'com.evervault:lib:2.0.4'
 <dependency>
   <groupId>com.evervault</groupId>
   <artifactId>lib</artifactId>
-  <version>2.0.4</version>
+  <version>2.0.5</version>
 </dependency>
 ```
 
@@ -186,3 +186,8 @@ void encryptAndRun() throws EvervaultException {
 ### 2.0.4
 
 * Fix issue with Java 11 Http Client and proxy
+
+
+### 2.0.5
+
+* Add Value for enabling BASIC auth with the proxy

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group 'com.evervault'
-version '2.0.4'
+version '2.0.5'
 
 repositories {
     mavenCentral()

--- a/lib/src/main/java/com/evervault/utils/ProxySystemSettings.java
+++ b/lib/src/main/java/com/evervault/utils/ProxySystemSettings.java
@@ -1,0 +1,6 @@
+package com.evervault.utils;
+
+public class ProxySystemSettings {
+    public static String PROXY_DISABLED_SCHEMES_KEY = "jdk.http.auth.tunneling.disabledSchemes";
+    public static String PROXY_DISABLED_SCHEMES_VALUE = ""; //Needs to be empty as BASIC auth is disabled by default
+}


### PR DESCRIPTION
# Why

The Java 11 HTTP Client needs this setting to be set before the SDK is initialised.

# How

Added public String to package so it can be added easily. Also updated readme.

Bumped to v2.0.5

### Commit Messages

We use [semantic-release](https://github.com/semantic-release/semantic-release#how-does-it-work) for deployments. If one of your commits should be deployed, ensure the commit message is in the format corresponding to the correct release type. This can also be done in a squash commit.

Note: breaking changes should always use the `BREAKING CHANGE:` commit message format.
