### PR TITLE
fix: Add KDF when deriving shared secret for NIST curve

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Our Java SDK is distributed via [maven](https://search.maven.org/artifact/com.ev
 
 ### Gradle
 ```sh
-implementation 'com.evervault:lib:2.0.5'
+implementation 'com.evervault:lib:2.0.6'
 ```
 
 ### Maven
@@ -38,7 +38,7 @@ implementation 'com.evervault:lib:2.0.5'
 <dependency>
   <groupId>com.evervault</groupId>
   <artifactId>lib</artifactId>
-  <version>2.0.5</version>
+  <version>2.0.6</version>
 </dependency>
 ```
 
@@ -198,3 +198,9 @@ void encryptAndRun() throws EvervaultException {
 ### 2.0.5
 
 * Add Value for enabling BASIC auth with the proxy
+
+### 2.0.6
+
+* Add KDF when deriving shared secret
+
+* Add AAD when encrypting with Secp256r1 curve

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group 'com.evervault'
-version '2.0.5'
+version '2.0.6'
 
 repositories {
     mavenCentral()
@@ -35,6 +35,7 @@ dependencies {
     testImplementation "org.mockito:mockito-core:3.+"
 
     implementation 'com.google.code.gson:gson:2.8.9'
+    implementation 'com.google.guava:guava:11.0.2'
     implementation group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: '1.70'
 }
 

--- a/lib/src/integrationTests/java/com/evervault/WhenUsingApiAgainstRealEnvironmentTests.java
+++ b/lib/src/integrationTests/java/com/evervault/WhenUsingApiAgainstRealEnvironmentTests.java
@@ -23,7 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class WhenUsingApiAgainstRealEnvironmentTests {
     private static final String ENV_API_KEY = "ENVIRONMENT_API_KEY";
-    private static final String DEFAULT_CAGE_NAME = "java-sdk-integration-tests";
+    private static final String DEFAULT_CAGE_NAME = "java-integration-test-cage";
     private static final String EV_CAGE_ENV_KEY = "EV_CAGE_NAME";
     private String cageName;
 
@@ -83,8 +83,8 @@ public class WhenUsingApiAgainstRealEnvironmentTests {
     @Test
     void encryptAndRun() throws EvervaultException {
         var evervault = new Evervault(getEnvironmentApiKey());
-
-        var cageResult = evervault.run(cageName, Bar.createFooStructure(evervault), false, null);
+        var data = Bar.createFooStructure(evervault);
+        var cageResult = evervault.run(cageName, data, false, null);
 
         assert !cageResult.runId.isEmpty();
     }
@@ -92,8 +92,8 @@ public class WhenUsingApiAgainstRealEnvironmentTests {
     @Test
     void encryptAndRunR1Curve() throws EvervaultException {
         var evervault = new Evervault(getEnvironmentApiKey(), EcdhCurve.SECP256R1);
-
-        var cageResult = evervault.run(cageName, Bar.createFooStructure(evervault), false, null);
+        var data = Bar.createFooStructure(evervault);
+        var cageResult = evervault.run(cageName, data, false, null);
 
         assert !cageResult.runId.isEmpty();
     }

--- a/lib/src/main/java/com/evervault/Evervault.java
+++ b/lib/src/main/java/com/evervault/Evervault.java
@@ -4,12 +4,14 @@ import com.evervault.exceptions.EvervaultException;
 import com.evervault.services.*;
 import com.evervault.utils.EcdhCurve;
 
+import org.bouncycastle.jcajce.provider.asymmetric.ec.BCECPublicKey;
+
 import java.util.Objects;
 
 public class Evervault extends EvervaultService {
-    private static final String EVERVAULT_API_HOST = "api.evervault.com";
-    private static final String EVERVAULT_RUN_HOST = "run.evervault.com";
-    private static final String EVERVAULT_RELAY_HOST = "strict.relay.evervault.com";
+    private static final String EVERVAULT_API_HOST = "api.evervault.io";
+    private static final String EVERVAULT_RUN_HOST = "run.evervault.io";
+    private static final String EVERVAULT_RELAY_HOST = "strict.relay.evervault.io";
 
     private String evervaultApiHost;
     private String evervaultRunHost;
@@ -108,8 +110,7 @@ public class Evervault extends EvervaultService {
         this.setupCageExecutionProvider(httpHandler);
 
         this.setupKeyProviders(httpHandler, encryptService, encryptService, timeService, ecdhCurve);
-
-        var encryptForObject = new EvervaultEncryptionService(encryptService, this.generatedEcdhKey, this.sharedKey);
+        var encryptForObject = new EvervaultEncryptionService(encryptService, this.generatedEcdhKey, this.sharedKey, ((BCECPublicKey) this.teamKey).getQ().getEncoded(true));
 
         this.setupEncryption(encryptForObject);
 

--- a/lib/src/main/java/com/evervault/Evervault.java
+++ b/lib/src/main/java/com/evervault/Evervault.java
@@ -4,8 +4,6 @@ import com.evervault.exceptions.EvervaultException;
 import com.evervault.services.*;
 import com.evervault.utils.EcdhCurve;
 
-import org.bouncycastle.jcajce.provider.asymmetric.ec.BCECPublicKey;
-
 import java.util.Objects;
 
 public class Evervault extends EvervaultService {
@@ -110,8 +108,7 @@ public class Evervault extends EvervaultService {
         this.setupCageExecutionProvider(httpHandler);
 
         this.setupKeyProviders(httpHandler, encryptService, encryptService, timeService, ecdhCurve);
-        var teamPublicKey = ((BCECPublicKey) this.teamKey).getQ().getEncoded(true);
-        var encryptForObject = new EvervaultEncryptionService(encryptService, this.generatedEcdhKey, this.sharedKey, teamPublicKey);
+        var encryptForObject = new EvervaultEncryptionService(encryptService, this.generatedEcdhKey, this.sharedKey, this.teamKey);
 
         this.setupEncryption(encryptForObject);
 

--- a/lib/src/main/java/com/evervault/Evervault.java
+++ b/lib/src/main/java/com/evervault/Evervault.java
@@ -9,9 +9,9 @@ import org.bouncycastle.jcajce.provider.asymmetric.ec.BCECPublicKey;
 import java.util.Objects;
 
 public class Evervault extends EvervaultService {
-    private static final String EVERVAULT_API_HOST = "api.evervault.io";
-    private static final String EVERVAULT_RUN_HOST = "run.evervault.io";
-    private static final String EVERVAULT_RELAY_HOST = "strict.relay.evervault.io";
+    private static final String EVERVAULT_API_HOST = "api.evervault.com";
+    private static final String EVERVAULT_RUN_HOST = "run.evervault.com";
+    private static final String EVERVAULT_RELAY_HOST = "strict.relay.evervault.com";
 
     private String evervaultApiHost;
     private String evervaultRunHost;
@@ -110,7 +110,8 @@ public class Evervault extends EvervaultService {
         this.setupCageExecutionProvider(httpHandler);
 
         this.setupKeyProviders(httpHandler, encryptService, encryptService, timeService, ecdhCurve);
-        var encryptForObject = new EvervaultEncryptionService(encryptService, this.generatedEcdhKey, this.sharedKey, ((BCECPublicKey) this.teamKey).getQ().getEncoded(true));
+        var teamPublicKey = ((BCECPublicKey) this.teamKey).getQ().getEncoded(true);
+        var encryptForObject = new EvervaultEncryptionService(encryptService, this.generatedEcdhKey, this.sharedKey, teamPublicKey);
 
         this.setupEncryption(encryptForObject);
 

--- a/lib/src/main/java/com/evervault/contracts/IDataHandler.java
+++ b/lib/src/main/java/com/evervault/contracts/IDataHandler.java
@@ -1,11 +1,12 @@
 package com.evervault.contracts;
 
 import com.evervault.exceptions.InvalidCipherException;
+import com.evervault.exceptions.NotImplementedException;
 import com.evervault.exceptions.NotPossibleToHandleDataTypeException;
 
 import java.io.IOException;
 
 public interface IDataHandler {
     boolean canEncrypt(Object data);
-    Object encrypt(IProvideEncryptionForObject context, Object data) throws NotPossibleToHandleDataTypeException, IOException, InvalidCipherException;
+    Object encrypt(IProvideEncryptionForObject context, Object data) throws NotPossibleToHandleDataTypeException, IOException, InvalidCipherException, NotImplementedException;
 }

--- a/lib/src/main/java/com/evervault/contracts/IProvideEncryption.java
+++ b/lib/src/main/java/com/evervault/contracts/IProvideEncryption.java
@@ -1,8 +1,10 @@
 package com.evervault.contracts;
 
+import java.security.PublicKey;
+
 import com.evervault.exceptions.InvalidCipherException;
 import com.evervault.exceptions.NotImplementedException;
 
 public interface IProvideEncryption {
-    String encryptData(DataHeader header, byte[] generatedEcdhKey, byte[] data, byte[] sharedKey, byte[] teamPublicKey) throws InvalidCipherException, NotImplementedException;
+    String encryptData(DataHeader header, byte[] generatedEcdhKey, byte[] data, byte[] sharedKey, PublicKey teamPublicKey) throws InvalidCipherException, NotImplementedException;
 }

--- a/lib/src/main/java/com/evervault/contracts/IProvideEncryption.java
+++ b/lib/src/main/java/com/evervault/contracts/IProvideEncryption.java
@@ -1,7 +1,8 @@
 package com.evervault.contracts;
 
 import com.evervault.exceptions.InvalidCipherException;
+import com.evervault.exceptions.NotImplementedException;
 
 public interface IProvideEncryption {
-    String encryptData(DataHeader header, byte[] generatedEcdhKey, byte[] data, byte[] sharedKey) throws InvalidCipherException;
+    String encryptData(DataHeader header, byte[] generatedEcdhKey, byte[] data, byte[] sharedKey, byte[] teamPublicKey) throws InvalidCipherException, NotImplementedException;
 }

--- a/lib/src/main/java/com/evervault/contracts/IProvideEncryptionForObject.java
+++ b/lib/src/main/java/com/evervault/contracts/IProvideEncryptionForObject.java
@@ -1,10 +1,11 @@
 package com.evervault.contracts;
 
 import com.evervault.exceptions.InvalidCipherException;
+import com.evervault.exceptions.NotImplementedException;
 import com.evervault.exceptions.NotPossibleToHandleDataTypeException;
 
 import java.io.IOException;
 
 public interface IProvideEncryptionForObject {
-    Object encrypt(Object data) throws NotPossibleToHandleDataTypeException, IOException, InvalidCipherException;
+    Object encrypt(Object data) throws NotPossibleToHandleDataTypeException, IOException, InvalidCipherException, NotImplementedException;
 }

--- a/lib/src/main/java/com/evervault/contracts/IProvideSharedKey.java
+++ b/lib/src/main/java/com/evervault/contracts/IProvideSharedKey.java
@@ -1,6 +1,7 @@
 package com.evervault.contracts;
 
 import com.evervault.models.GeneratedSharedKey;
+import com.evervault.exceptions.Asn1EncodingException;
 import com.evervault.exceptions.NotImplementedException;
 
 import java.security.InvalidAlgorithmParameterException;
@@ -9,5 +10,5 @@ import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
 
 public interface IProvideSharedKey {
-    GeneratedSharedKey generateSharedKeyBasedOn(PublicKey teamCagePublickey) throws NoSuchAlgorithmException, InvalidAlgorithmParameterException, InvalidKeyException, NotImplementedException;
+    GeneratedSharedKey generateSharedKeyBasedOn(PublicKey teamCagePublickey) throws NoSuchAlgorithmException, InvalidAlgorithmParameterException, InvalidKeyException, NotImplementedException, Asn1EncodingException;
 }

--- a/lib/src/main/java/com/evervault/dataHandlers/ArrayHandler.java
+++ b/lib/src/main/java/com/evervault/dataHandlers/ArrayHandler.java
@@ -3,7 +3,9 @@ package com.evervault.dataHandlers;
 import com.evervault.contracts.IProvideEncryptionForObject;
 import com.evervault.contracts.IDataHandler;
 import com.evervault.exceptions.InvalidCipherException;
+import com.evervault.exceptions.NotImplementedException;
 import com.evervault.exceptions.NotPossibleToHandleDataTypeException;
+
 import java.io.IOException;
 import java.util.Vector;
 
@@ -14,7 +16,7 @@ public class ArrayHandler implements IDataHandler {
     }
 
     @Override
-    public Object encrypt(IProvideEncryptionForObject context, Object data) throws NotPossibleToHandleDataTypeException, IOException, InvalidCipherException {
+    public Object encrypt(IProvideEncryptionForObject context, Object data) throws NotPossibleToHandleDataTypeException, IOException, InvalidCipherException, NotImplementedException {
         var itemList = new Vector<>();
 
         for (var item: (Object[]) data) {

--- a/lib/src/main/java/com/evervault/dataHandlers/BooleanHandler.java
+++ b/lib/src/main/java/com/evervault/dataHandlers/BooleanHandler.java
@@ -5,17 +5,20 @@ import com.evervault.contracts.IProvideEncryptionForObject;
 import com.evervault.contracts.IDataHandler;
 import com.evervault.contracts.IProvideEncryption;
 import com.evervault.exceptions.InvalidCipherException;
+import com.evervault.exceptions.NotImplementedException;
 import com.evervault.exceptions.NotPossibleToHandleDataTypeException;
 
 public class BooleanHandler implements IDataHandler {
     private final IProvideEncryption encryptionProvider;
     private final byte[] generatedEcdhKey;
     private final byte[] sharedKey;
+    private byte[] teamPublicKey;
 
-    public BooleanHandler(IProvideEncryption encryptionProvider, byte[] generatedEcdhKey, byte[] sharedKey) {
+    public BooleanHandler(IProvideEncryption encryptionProvider, byte[] generatedEcdhKey, byte[] sharedKey, byte[] teamPublicKey) {
         this.encryptionProvider = encryptionProvider;
         this.generatedEcdhKey = generatedEcdhKey;
         this.sharedKey = sharedKey;
+        this.teamPublicKey = teamPublicKey;
     }
 
     @Override
@@ -24,10 +27,10 @@ public class BooleanHandler implements IDataHandler {
     }
 
     @Override
-    public Object encrypt(IProvideEncryptionForObject context, Object data) throws NotPossibleToHandleDataTypeException, InvalidCipherException {
+    public Object encrypt(IProvideEncryptionForObject context, Object data) throws NotPossibleToHandleDataTypeException, InvalidCipherException, NotImplementedException {
         var original = (boolean) data;
         var byteToEncrypt = original ? (byte)1 : (byte)0;
 
-        return encryptionProvider.encryptData(DataHeader.Boolean, generatedEcdhKey, new byte[] { byteToEncrypt }, sharedKey);
+        return encryptionProvider.encryptData(DataHeader.Boolean, generatedEcdhKey, new byte[] { byteToEncrypt }, sharedKey, teamPublicKey);
     }
 }

--- a/lib/src/main/java/com/evervault/dataHandlers/BooleanHandler.java
+++ b/lib/src/main/java/com/evervault/dataHandlers/BooleanHandler.java
@@ -1,5 +1,7 @@
 package com.evervault.dataHandlers;
 
+import java.security.PublicKey;
+
 import com.evervault.contracts.DataHeader;
 import com.evervault.contracts.IProvideEncryptionForObject;
 import com.evervault.contracts.IDataHandler;
@@ -12,9 +14,9 @@ public class BooleanHandler implements IDataHandler {
     private final IProvideEncryption encryptionProvider;
     private final byte[] generatedEcdhKey;
     private final byte[] sharedKey;
-    private byte[] teamPublicKey;
+    private PublicKey teamPublicKey;
 
-    public BooleanHandler(IProvideEncryption encryptionProvider, byte[] generatedEcdhKey, byte[] sharedKey, byte[] teamPublicKey) {
+    public BooleanHandler(IProvideEncryption encryptionProvider, byte[] generatedEcdhKey, byte[] sharedKey, PublicKey teamPublicKey) {
         this.encryptionProvider = encryptionProvider;
         this.generatedEcdhKey = generatedEcdhKey;
         this.sharedKey = sharedKey;

--- a/lib/src/main/java/com/evervault/dataHandlers/ByteHandler.java
+++ b/lib/src/main/java/com/evervault/dataHandlers/ByteHandler.java
@@ -5,17 +5,20 @@ import com.evervault.contracts.IProvideEncryptionForObject;
 import com.evervault.contracts.IDataHandler;
 import com.evervault.contracts.IProvideEncryption;
 import com.evervault.exceptions.InvalidCipherException;
+import com.evervault.exceptions.NotImplementedException;
 import com.evervault.exceptions.NotPossibleToHandleDataTypeException;
 
 public class ByteHandler implements IDataHandler {
     private final IProvideEncryption encryptionProvider;
     private final byte[] generatedEcdhKey;
     private final byte[] sharedKey;
-
-    public ByteHandler(IProvideEncryption encryptionProvider, byte[] generatedEcdhKey, byte[] sharedKey) {
+    private byte[] teamPublicKey;
+ 
+    public ByteHandler(IProvideEncryption encryptionProvider, byte[] generatedEcdhKey, byte[] sharedKey, byte[] teamPublicKey) {
         this.encryptionProvider = encryptionProvider;
         this.generatedEcdhKey = generatedEcdhKey;
         this.sharedKey = sharedKey;
+        this.teamPublicKey = teamPublicKey;
     }
 
     @Override
@@ -24,7 +27,7 @@ public class ByteHandler implements IDataHandler {
     }
 
     @Override
-    public Object encrypt(IProvideEncryptionForObject context, Object data) throws NotPossibleToHandleDataTypeException, InvalidCipherException {
-        return encryptionProvider.encryptData(DataHeader.String, generatedEcdhKey, new byte[] { (Byte)data }, sharedKey);
+    public Object encrypt(IProvideEncryptionForObject context, Object data) throws NotPossibleToHandleDataTypeException, InvalidCipherException, NotImplementedException {
+        return encryptionProvider.encryptData(DataHeader.String, generatedEcdhKey, new byte[] { (Byte)data }, sharedKey, teamPublicKey);
     }
 }

--- a/lib/src/main/java/com/evervault/dataHandlers/ByteHandler.java
+++ b/lib/src/main/java/com/evervault/dataHandlers/ByteHandler.java
@@ -1,5 +1,7 @@
 package com.evervault.dataHandlers;
 
+import java.security.PublicKey;
+
 import com.evervault.contracts.DataHeader;
 import com.evervault.contracts.IProvideEncryptionForObject;
 import com.evervault.contracts.IDataHandler;
@@ -12,9 +14,9 @@ public class ByteHandler implements IDataHandler {
     private final IProvideEncryption encryptionProvider;
     private final byte[] generatedEcdhKey;
     private final byte[] sharedKey;
-    private byte[] teamPublicKey;
+    private PublicKey teamPublicKey;
  
-    public ByteHandler(IProvideEncryption encryptionProvider, byte[] generatedEcdhKey, byte[] sharedKey, byte[] teamPublicKey) {
+    public ByteHandler(IProvideEncryption encryptionProvider, byte[] generatedEcdhKey, byte[] sharedKey, PublicKey teamPublicKey) {
         this.encryptionProvider = encryptionProvider;
         this.generatedEcdhKey = generatedEcdhKey;
         this.sharedKey = sharedKey;

--- a/lib/src/main/java/com/evervault/dataHandlers/CharHandler.java
+++ b/lib/src/main/java/com/evervault/dataHandlers/CharHandler.java
@@ -9,6 +9,7 @@ import com.evervault.exceptions.NotImplementedException;
 import com.evervault.exceptions.NotPossibleToHandleDataTypeException;
 
 import java.nio.ByteBuffer;
+import java.security.PublicKey;
 
 public class CharHandler implements IDataHandler {
     /// Size of char in java is 16bit unicode
@@ -17,9 +18,9 @@ public class CharHandler implements IDataHandler {
     private final IProvideEncryption encryptionProvider;
     private final byte[] generatedEcdhKey;
     private final byte[] sharedKey;
-    private final byte[] teamPublicKey;
+    private final PublicKey teamPublicKey;
 
-    public CharHandler(IProvideEncryption encryptionProvider, byte[] generatedEcdhKey, byte[] sharedKey, byte[] teamPublicKey) {
+    public CharHandler(IProvideEncryption encryptionProvider, byte[] generatedEcdhKey, byte[] sharedKey, PublicKey teamPublicKey) {
         this.encryptionProvider = encryptionProvider;
         this.generatedEcdhKey = generatedEcdhKey;
         this.sharedKey = sharedKey;

--- a/lib/src/main/java/com/evervault/dataHandlers/CharHandler.java
+++ b/lib/src/main/java/com/evervault/dataHandlers/CharHandler.java
@@ -5,6 +5,7 @@ import com.evervault.contracts.IDataHandler;
 import com.evervault.contracts.IProvideEncryptionForObject;
 import com.evervault.contracts.IProvideEncryption;
 import com.evervault.exceptions.InvalidCipherException;
+import com.evervault.exceptions.NotImplementedException;
 import com.evervault.exceptions.NotPossibleToHandleDataTypeException;
 
 import java.nio.ByteBuffer;
@@ -16,11 +17,13 @@ public class CharHandler implements IDataHandler {
     private final IProvideEncryption encryptionProvider;
     private final byte[] generatedEcdhKey;
     private final byte[] sharedKey;
+    private final byte[] teamPublicKey;
 
-    public CharHandler(IProvideEncryption encryptionProvider, byte[] generatedEcdhKey, byte[] sharedKey) {
+    public CharHandler(IProvideEncryption encryptionProvider, byte[] generatedEcdhKey, byte[] sharedKey, byte[] teamPublicKey) {
         this.encryptionProvider = encryptionProvider;
         this.generatedEcdhKey = generatedEcdhKey;
         this.sharedKey = sharedKey;
+        this.teamPublicKey = teamPublicKey;
     }
 
     @Override
@@ -29,9 +32,9 @@ public class CharHandler implements IDataHandler {
     }
 
     @Override
-    public Object encrypt(IProvideEncryptionForObject context, Object data) throws NotPossibleToHandleDataTypeException, InvalidCipherException {
+    public Object encrypt(IProvideEncryptionForObject context, Object data) throws NotPossibleToHandleDataTypeException, InvalidCipherException, NotImplementedException {
         var bytes = ByteBuffer.allocate(BUFFER_SIZE).putChar((char) data).array();
 
-        return encryptionProvider.encryptData(DataHeader.String, generatedEcdhKey, bytes, sharedKey);
+        return encryptionProvider.encryptData(DataHeader.String, generatedEcdhKey, bytes, sharedKey, teamPublicKey);
     }
 }

--- a/lib/src/main/java/com/evervault/dataHandlers/DoubleHandler.java
+++ b/lib/src/main/java/com/evervault/dataHandlers/DoubleHandler.java
@@ -5,6 +5,7 @@ import com.evervault.contracts.IProvideEncryptionForObject;
 import com.evervault.contracts.IDataHandler;
 import com.evervault.contracts.IProvideEncryption;
 import com.evervault.exceptions.InvalidCipherException;
+import com.evervault.exceptions.NotImplementedException;
 import com.evervault.exceptions.NotPossibleToHandleDataTypeException;
 
 import java.nio.ByteBuffer;
@@ -15,11 +16,13 @@ public class DoubleHandler implements IDataHandler {
     private final IProvideEncryption encryptionProvider;
     private final byte[] generatedEcdhKey;
     private final byte[] sharedKey;
+    private byte[] teamPublicKey;
 
-    public DoubleHandler(IProvideEncryption encryptionProvider, byte[] generatedEcdhKey, byte[] sharedKey) {
+    public DoubleHandler(IProvideEncryption encryptionProvider, byte[] generatedEcdhKey, byte[] sharedKey, byte[] teamPublicKey) {
         this.encryptionProvider = encryptionProvider;
         this.generatedEcdhKey = generatedEcdhKey;
         this.sharedKey = sharedKey;
+        this.teamPublicKey = teamPublicKey;
     }
 
     @Override
@@ -28,9 +31,9 @@ public class DoubleHandler implements IDataHandler {
     }
 
     @Override
-    public Object encrypt(IProvideEncryptionForObject context, Object data) throws NotPossibleToHandleDataTypeException, InvalidCipherException {
+    public Object encrypt(IProvideEncryptionForObject context, Object data) throws NotPossibleToHandleDataTypeException, InvalidCipherException, NotImplementedException {
         var bytes = ByteBuffer.allocate(BUFFER_SIZE).putDouble((double) data).array();
 
-        return encryptionProvider.encryptData(DataHeader.Number, generatedEcdhKey, bytes, sharedKey);
+        return encryptionProvider.encryptData(DataHeader.Number, generatedEcdhKey, bytes, sharedKey, teamPublicKey);
     }
 }

--- a/lib/src/main/java/com/evervault/dataHandlers/DoubleHandler.java
+++ b/lib/src/main/java/com/evervault/dataHandlers/DoubleHandler.java
@@ -9,6 +9,7 @@ import com.evervault.exceptions.NotImplementedException;
 import com.evervault.exceptions.NotPossibleToHandleDataTypeException;
 
 import java.nio.ByteBuffer;
+import java.security.PublicKey;
 
 public class DoubleHandler implements IDataHandler {
     private static final int BUFFER_SIZE = 8;
@@ -16,9 +17,9 @@ public class DoubleHandler implements IDataHandler {
     private final IProvideEncryption encryptionProvider;
     private final byte[] generatedEcdhKey;
     private final byte[] sharedKey;
-    private byte[] teamPublicKey;
+    private PublicKey teamPublicKey;
 
-    public DoubleHandler(IProvideEncryption encryptionProvider, byte[] generatedEcdhKey, byte[] sharedKey, byte[] teamPublicKey) {
+    public DoubleHandler(IProvideEncryption encryptionProvider, byte[] generatedEcdhKey, byte[] sharedKey, PublicKey teamPublicKey) {
         this.encryptionProvider = encryptionProvider;
         this.generatedEcdhKey = generatedEcdhKey;
         this.sharedKey = sharedKey;

--- a/lib/src/main/java/com/evervault/dataHandlers/FloatHandler.java
+++ b/lib/src/main/java/com/evervault/dataHandlers/FloatHandler.java
@@ -5,6 +5,7 @@ import com.evervault.contracts.IDataHandler;
 import com.evervault.contracts.IProvideEncryptionForObject;
 import com.evervault.contracts.IProvideEncryption;
 import com.evervault.exceptions.InvalidCipherException;
+import com.evervault.exceptions.NotImplementedException;
 import com.evervault.exceptions.NotPossibleToHandleDataTypeException;
 
 import java.nio.ByteBuffer;
@@ -15,11 +16,13 @@ public class FloatHandler implements IDataHandler {
     private final IProvideEncryption encryptionProvider;
     private final byte[] generatedEcdhKey;
     private final byte[] sharedKey;
+    private byte[] teamPublicKey;
 
-    public FloatHandler(IProvideEncryption encryptionProvider, byte[] generatedEcdhKey, byte[] sharedKey) {
+    public FloatHandler(IProvideEncryption encryptionProvider, byte[] generatedEcdhKey, byte[] sharedKey, byte[] teamPublicKey) {
         this.encryptionProvider = encryptionProvider;
         this.generatedEcdhKey = generatedEcdhKey;
         this.sharedKey = sharedKey;
+        this.teamPublicKey = teamPublicKey;
     }
 
     @Override
@@ -28,9 +31,9 @@ public class FloatHandler implements IDataHandler {
     }
 
     @Override
-    public Object encrypt(IProvideEncryptionForObject context, Object data) throws NotPossibleToHandleDataTypeException, InvalidCipherException {
+    public Object encrypt(IProvideEncryptionForObject context, Object data) throws NotPossibleToHandleDataTypeException, InvalidCipherException, NotImplementedException {
         var bytes = ByteBuffer.allocate(BUFFER_SIZE).putFloat((float) data).array();
 
-        return encryptionProvider.encryptData(DataHeader.Number, generatedEcdhKey, bytes, sharedKey);
+        return encryptionProvider.encryptData(DataHeader.Number, generatedEcdhKey, bytes, sharedKey, teamPublicKey);
     }
 }

--- a/lib/src/main/java/com/evervault/dataHandlers/FloatHandler.java
+++ b/lib/src/main/java/com/evervault/dataHandlers/FloatHandler.java
@@ -9,6 +9,7 @@ import com.evervault.exceptions.NotImplementedException;
 import com.evervault.exceptions.NotPossibleToHandleDataTypeException;
 
 import java.nio.ByteBuffer;
+import java.security.PublicKey;
 
 public class FloatHandler implements IDataHandler {
     private static final int BUFFER_SIZE = 4;
@@ -16,9 +17,9 @@ public class FloatHandler implements IDataHandler {
     private final IProvideEncryption encryptionProvider;
     private final byte[] generatedEcdhKey;
     private final byte[] sharedKey;
-    private byte[] teamPublicKey;
+    private PublicKey teamPublicKey;
 
-    public FloatHandler(IProvideEncryption encryptionProvider, byte[] generatedEcdhKey, byte[] sharedKey, byte[] teamPublicKey) {
+    public FloatHandler(IProvideEncryption encryptionProvider, byte[] generatedEcdhKey, byte[] sharedKey, PublicKey teamPublicKey) {
         this.encryptionProvider = encryptionProvider;
         this.generatedEcdhKey = generatedEcdhKey;
         this.sharedKey = sharedKey;

--- a/lib/src/main/java/com/evervault/dataHandlers/IntegerHandler.java
+++ b/lib/src/main/java/com/evervault/dataHandlers/IntegerHandler.java
@@ -5,7 +5,9 @@ import com.evervault.contracts.IProvideEncryptionForObject;
 import com.evervault.contracts.IDataHandler;
 import com.evervault.contracts.IProvideEncryption;
 import com.evervault.exceptions.InvalidCipherException;
+import com.evervault.exceptions.NotImplementedException;
 import com.evervault.exceptions.NotPossibleToHandleDataTypeException;
+
 import java.nio.ByteBuffer;
 
 public class IntegerHandler implements IDataHandler {
@@ -14,11 +16,13 @@ public class IntegerHandler implements IDataHandler {
     private final IProvideEncryption encryptionProvider;
     private final byte[] generatedEcdhKey;
     private final byte[] sharedKey;
+    private byte[] teamPublicKey;
 
-    public IntegerHandler(IProvideEncryption encryptionProvider, byte[] generatedEcdhKey, byte[] sharedKey) {
+    public IntegerHandler(IProvideEncryption encryptionProvider, byte[] generatedEcdhKey, byte[] sharedKey, byte[] teamPublicKey) {
         this.encryptionProvider = encryptionProvider;
         this.generatedEcdhKey = generatedEcdhKey;
         this.sharedKey = sharedKey;
+        this.teamPublicKey = teamPublicKey;
     }
 
     @Override
@@ -27,9 +31,9 @@ public class IntegerHandler implements IDataHandler {
     }
 
     @Override
-    public Object encrypt(IProvideEncryptionForObject context, Object data) throws NotPossibleToHandleDataTypeException, InvalidCipherException {
+    public Object encrypt(IProvideEncryptionForObject context, Object data) throws NotPossibleToHandleDataTypeException, InvalidCipherException, NotImplementedException {
         var bytes = ByteBuffer.allocate(BUFFER_SIZE).putInt((int) data).array();
 
-        return encryptionProvider.encryptData(DataHeader.Number, generatedEcdhKey, bytes, sharedKey);
+        return encryptionProvider.encryptData(DataHeader.Number, generatedEcdhKey, bytes, sharedKey, teamPublicKey);
     }
 }

--- a/lib/src/main/java/com/evervault/dataHandlers/IntegerHandler.java
+++ b/lib/src/main/java/com/evervault/dataHandlers/IntegerHandler.java
@@ -9,6 +9,7 @@ import com.evervault.exceptions.NotImplementedException;
 import com.evervault.exceptions.NotPossibleToHandleDataTypeException;
 
 import java.nio.ByteBuffer;
+import java.security.PublicKey;
 
 public class IntegerHandler implements IDataHandler {
     private static final int BUFFER_SIZE = 4;
@@ -16,9 +17,9 @@ public class IntegerHandler implements IDataHandler {
     private final IProvideEncryption encryptionProvider;
     private final byte[] generatedEcdhKey;
     private final byte[] sharedKey;
-    private byte[] teamPublicKey;
+    private PublicKey teamPublicKey;
 
-    public IntegerHandler(IProvideEncryption encryptionProvider, byte[] generatedEcdhKey, byte[] sharedKey, byte[] teamPublicKey) {
+    public IntegerHandler(IProvideEncryption encryptionProvider, byte[] generatedEcdhKey, byte[] sharedKey, PublicKey teamPublicKey) {
         this.encryptionProvider = encryptionProvider;
         this.generatedEcdhKey = generatedEcdhKey;
         this.sharedKey = sharedKey;

--- a/lib/src/main/java/com/evervault/dataHandlers/LongHandler.java
+++ b/lib/src/main/java/com/evervault/dataHandlers/LongHandler.java
@@ -9,6 +9,7 @@ import com.evervault.exceptions.NotImplementedException;
 import com.evervault.exceptions.NotPossibleToHandleDataTypeException;
 
 import java.nio.ByteBuffer;
+import java.security.PublicKey;
 
 public class LongHandler implements IDataHandler {
     private static final int BUFFER_SIZE = 8;
@@ -16,9 +17,9 @@ public class LongHandler implements IDataHandler {
     private final IProvideEncryption encryptionProvider;
     private final byte[] generatedEcdhKey;
     private final byte[] sharedKey;
-    private byte[] teamPublicKey;
+    private PublicKey teamPublicKey;
 
-    public LongHandler(IProvideEncryption encryptionProvider, byte[] generatedEcdhKey, byte[] sharedKey, byte[] teamPublicKey) {
+    public LongHandler(IProvideEncryption encryptionProvider, byte[] generatedEcdhKey, byte[] sharedKey, PublicKey teamPublicKey) {
         this.encryptionProvider = encryptionProvider;
         this.generatedEcdhKey = generatedEcdhKey;
         this.sharedKey = sharedKey;

--- a/lib/src/main/java/com/evervault/dataHandlers/LongHandler.java
+++ b/lib/src/main/java/com/evervault/dataHandlers/LongHandler.java
@@ -5,6 +5,7 @@ import com.evervault.contracts.IProvideEncryptionForObject;
 import com.evervault.contracts.IDataHandler;
 import com.evervault.contracts.IProvideEncryption;
 import com.evervault.exceptions.InvalidCipherException;
+import com.evervault.exceptions.NotImplementedException;
 import com.evervault.exceptions.NotPossibleToHandleDataTypeException;
 
 import java.nio.ByteBuffer;
@@ -15,11 +16,13 @@ public class LongHandler implements IDataHandler {
     private final IProvideEncryption encryptionProvider;
     private final byte[] generatedEcdhKey;
     private final byte[] sharedKey;
+    private byte[] teamPublicKey;
 
-    public LongHandler(IProvideEncryption encryptionProvider, byte[] generatedEcdhKey, byte[] sharedKey) {
+    public LongHandler(IProvideEncryption encryptionProvider, byte[] generatedEcdhKey, byte[] sharedKey, byte[] teamPublicKey) {
         this.encryptionProvider = encryptionProvider;
         this.generatedEcdhKey = generatedEcdhKey;
         this.sharedKey = sharedKey;
+        this.teamPublicKey = teamPublicKey;
     }
 
     @Override
@@ -28,9 +31,9 @@ public class LongHandler implements IDataHandler {
     }
 
     @Override
-    public Object encrypt(IProvideEncryptionForObject context, Object data) throws NotPossibleToHandleDataTypeException, InvalidCipherException {
+    public Object encrypt(IProvideEncryptionForObject context, Object data) throws NotPossibleToHandleDataTypeException, InvalidCipherException, NotImplementedException {
         var bytes = ByteBuffer.allocate(BUFFER_SIZE).putLong((long) data).array();
 
-        return encryptionProvider.encryptData(DataHeader.Number, generatedEcdhKey, bytes, sharedKey);
+        return encryptionProvider.encryptData(DataHeader.Number, generatedEcdhKey, bytes, sharedKey, teamPublicKey);
     }
 }

--- a/lib/src/main/java/com/evervault/dataHandlers/MapHandler.java
+++ b/lib/src/main/java/com/evervault/dataHandlers/MapHandler.java
@@ -3,6 +3,7 @@ package com.evervault.dataHandlers;
 import com.evervault.contracts.IProvideEncryptionForObject;
 import com.evervault.contracts.IDataHandler;
 import com.evervault.exceptions.InvalidCipherException;
+import com.evervault.exceptions.NotImplementedException;
 import com.evervault.exceptions.NotPossibleToHandleDataTypeException;
 
 import java.io.IOException;
@@ -15,7 +16,7 @@ public class MapHandler implements IDataHandler {
     }
 
     @Override
-    public Object encrypt(IProvideEncryptionForObject context, Object data) throws NotPossibleToHandleDataTypeException, IOException, InvalidCipherException {
+    public Object encrypt(IProvideEncryptionForObject context, Object data) throws NotPossibleToHandleDataTypeException, IOException, InvalidCipherException, NotImplementedException {
         var map = (Map)data;
 
         for (var item :

--- a/lib/src/main/java/com/evervault/dataHandlers/SerializableHandler.java
+++ b/lib/src/main/java/com/evervault/dataHandlers/SerializableHandler.java
@@ -5,6 +5,7 @@ import com.evervault.contracts.IProvideEncryptionForObject;
 import com.evervault.contracts.IDataHandler;
 import com.evervault.contracts.IProvideEncryption;
 import com.evervault.exceptions.InvalidCipherException;
+import com.evervault.exceptions.NotImplementedException;
 import com.evervault.exceptions.NotPossibleToHandleDataTypeException;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -15,8 +16,9 @@ public class SerializableHandler implements IDataHandler {
     private final IProvideEncryption encryptionProvider;
     private final byte[] generatedEcdhKey;
     private final byte[] sharedKey;
+    private byte[] teamPublicKey;
 
-    public SerializableHandler(IProvideEncryption encryptionProvider, byte[] generatedEcdhKey, byte[] sharedKey) {
+    public SerializableHandler(IProvideEncryption encryptionProvider, byte[] generatedEcdhKey, byte[] sharedKey, byte[] teamPublicKey) {
         this.encryptionProvider = encryptionProvider;
         this.generatedEcdhKey = generatedEcdhKey;
         this.sharedKey = sharedKey;
@@ -28,7 +30,7 @@ public class SerializableHandler implements IDataHandler {
     }
 
     @Override
-    public Object encrypt(IProvideEncryptionForObject context, Object data) throws NotPossibleToHandleDataTypeException, IOException, InvalidCipherException {
+    public Object encrypt(IProvideEncryptionForObject context, Object data) throws NotPossibleToHandleDataTypeException, IOException, InvalidCipherException, NotImplementedException {
         var content = (Serializable)data;
 
         var outputStream = new ByteArrayOutputStream();
@@ -37,6 +39,6 @@ public class SerializableHandler implements IDataHandler {
 
         var byteArray = outputStream.toByteArray();
 
-        return encryptionProvider.encryptData(DataHeader.String, generatedEcdhKey, byteArray, sharedKey);
+        return encryptionProvider.encryptData(DataHeader.String, generatedEcdhKey, byteArray, sharedKey, teamPublicKey);
     }
 }

--- a/lib/src/main/java/com/evervault/dataHandlers/SerializableHandler.java
+++ b/lib/src/main/java/com/evervault/dataHandlers/SerializableHandler.java
@@ -11,14 +11,15 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
+import java.security.PublicKey;
 
 public class SerializableHandler implements IDataHandler {
     private final IProvideEncryption encryptionProvider;
     private final byte[] generatedEcdhKey;
     private final byte[] sharedKey;
-    private byte[] teamPublicKey;
+    private PublicKey teamPublicKey;
 
-    public SerializableHandler(IProvideEncryption encryptionProvider, byte[] generatedEcdhKey, byte[] sharedKey, byte[] teamPublicKey) {
+    public SerializableHandler(IProvideEncryption encryptionProvider, byte[] generatedEcdhKey, byte[] sharedKey, PublicKey teamPublicKey) {
         this.encryptionProvider = encryptionProvider;
         this.generatedEcdhKey = generatedEcdhKey;
         this.sharedKey = sharedKey;

--- a/lib/src/main/java/com/evervault/dataHandlers/ShortHandler.java
+++ b/lib/src/main/java/com/evervault/dataHandlers/ShortHandler.java
@@ -8,6 +8,7 @@ import com.evervault.exceptions.InvalidCipherException;
 import com.evervault.exceptions.NotImplementedException;
 import com.evervault.exceptions.NotPossibleToHandleDataTypeException;
 import java.nio.ByteBuffer;
+import java.security.PublicKey;
 
 public class ShortHandler implements IDataHandler {
     private static final int BUFFER_SIZE = 2;
@@ -15,9 +16,9 @@ public class ShortHandler implements IDataHandler {
     private final IProvideEncryption encryptionProvider;
     private final byte[] generatedEcdhKey;
     private final byte[] sharedKey;
-    private byte[] teamPublicKey;
+    private PublicKey teamPublicKey;
 
-    public ShortHandler(IProvideEncryption encryptionProvider, byte[] generatedEcdhKey, byte[] sharedKey, byte[] teamPublicKey) {
+    public ShortHandler(IProvideEncryption encryptionProvider, byte[] generatedEcdhKey, byte[] sharedKey, PublicKey teamPublicKey) {
         this.encryptionProvider = encryptionProvider;
         this.generatedEcdhKey = generatedEcdhKey;
         this.sharedKey = sharedKey;

--- a/lib/src/main/java/com/evervault/dataHandlers/ShortHandler.java
+++ b/lib/src/main/java/com/evervault/dataHandlers/ShortHandler.java
@@ -5,6 +5,7 @@ import com.evervault.contracts.IProvideEncryptionForObject;
 import com.evervault.contracts.IDataHandler;
 import com.evervault.contracts.IProvideEncryption;
 import com.evervault.exceptions.InvalidCipherException;
+import com.evervault.exceptions.NotImplementedException;
 import com.evervault.exceptions.NotPossibleToHandleDataTypeException;
 import java.nio.ByteBuffer;
 
@@ -14,11 +15,13 @@ public class ShortHandler implements IDataHandler {
     private final IProvideEncryption encryptionProvider;
     private final byte[] generatedEcdhKey;
     private final byte[] sharedKey;
+    private byte[] teamPublicKey;
 
-    public ShortHandler(IProvideEncryption encryptionProvider, byte[] generatedEcdhKey, byte[] sharedKey) {
+    public ShortHandler(IProvideEncryption encryptionProvider, byte[] generatedEcdhKey, byte[] sharedKey, byte[] teamPublicKey) {
         this.encryptionProvider = encryptionProvider;
         this.generatedEcdhKey = generatedEcdhKey;
         this.sharedKey = sharedKey;
+        this.teamPublicKey = teamPublicKey;
     }
 
     @Override
@@ -27,9 +30,9 @@ public class ShortHandler implements IDataHandler {
     }
 
     @Override
-    public Object encrypt(IProvideEncryptionForObject context, Object data) throws NotPossibleToHandleDataTypeException, InvalidCipherException {
+    public Object encrypt(IProvideEncryptionForObject context, Object data) throws NotPossibleToHandleDataTypeException, InvalidCipherException, NotImplementedException {
         var bytes = ByteBuffer.allocate(BUFFER_SIZE).putShort((short) data).array();
 
-        return encryptionProvider.encryptData(DataHeader.Number, generatedEcdhKey, bytes, sharedKey);
+        return encryptionProvider.encryptData(DataHeader.Number, generatedEcdhKey, bytes, sharedKey, teamPublicKey);
     }
 }

--- a/lib/src/main/java/com/evervault/dataHandlers/StringDataHandler.java
+++ b/lib/src/main/java/com/evervault/dataHandlers/StringDataHandler.java
@@ -5,6 +5,7 @@ import com.evervault.contracts.IProvideEncryptionForObject;
 import com.evervault.contracts.IDataHandler;
 import com.evervault.contracts.IProvideEncryption;
 import com.evervault.exceptions.InvalidCipherException;
+import com.evervault.exceptions.NotImplementedException;
 
 import java.nio.charset.StandardCharsets;
 
@@ -12,12 +13,14 @@ public class StringDataHandler implements IDataHandler {
     private final IProvideEncryption encryptionProvider;
     private final byte[] generatedEcdhKey;
     private final byte[] sharedKey;
+    private byte[] teamPublicKey;
 
-    public StringDataHandler(IProvideEncryption encryptionProvider, byte[] generatedEcdhKey, byte[] sharedKey)
+    public StringDataHandler(IProvideEncryption encryptionProvider, byte[] generatedEcdhKey, byte[] sharedKey, byte[] teamPublicKey)
     {
         this.encryptionProvider = encryptionProvider;
         this.generatedEcdhKey = generatedEcdhKey;
         this.sharedKey = sharedKey;
+        this.teamPublicKey = teamPublicKey;
     }
 
     @Override
@@ -26,7 +29,7 @@ public class StringDataHandler implements IDataHandler {
     }
 
     @Override
-    public String encrypt(IProvideEncryptionForObject context, Object data) throws InvalidCipherException {
-        return encryptionProvider.encryptData(DataHeader.String, generatedEcdhKey, ((String)data).getBytes(StandardCharsets.UTF_8), sharedKey);
+    public String encrypt(IProvideEncryptionForObject context, Object data) throws InvalidCipherException, NotImplementedException {
+        return encryptionProvider.encryptData(DataHeader.String, generatedEcdhKey, ((String)data).getBytes(StandardCharsets.UTF_8), sharedKey, teamPublicKey);
     }
 }

--- a/lib/src/main/java/com/evervault/dataHandlers/StringDataHandler.java
+++ b/lib/src/main/java/com/evervault/dataHandlers/StringDataHandler.java
@@ -8,14 +8,15 @@ import com.evervault.exceptions.InvalidCipherException;
 import com.evervault.exceptions.NotImplementedException;
 
 import java.nio.charset.StandardCharsets;
+import java.security.PublicKey;
 
 public class StringDataHandler implements IDataHandler {
     private final IProvideEncryption encryptionProvider;
     private final byte[] generatedEcdhKey;
     private final byte[] sharedKey;
-    private byte[] teamPublicKey;
+    private PublicKey teamPublicKey;
 
-    public StringDataHandler(IProvideEncryption encryptionProvider, byte[] generatedEcdhKey, byte[] sharedKey, byte[] teamPublicKey)
+    public StringDataHandler(IProvideEncryption encryptionProvider, byte[] generatedEcdhKey, byte[] sharedKey, PublicKey teamPublicKey)
     {
         this.encryptionProvider = encryptionProvider;
         this.generatedEcdhKey = generatedEcdhKey;

--- a/lib/src/main/java/com/evervault/dataHandlers/VectorHandler.java
+++ b/lib/src/main/java/com/evervault/dataHandlers/VectorHandler.java
@@ -3,6 +3,7 @@ package com.evervault.dataHandlers;
 import com.evervault.contracts.IProvideEncryptionForObject;
 import com.evervault.contracts.IDataHandler;
 import com.evervault.exceptions.InvalidCipherException;
+import com.evervault.exceptions.NotImplementedException;
 import com.evervault.exceptions.NotPossibleToHandleDataTypeException;
 
 import java.io.IOException;
@@ -15,7 +16,7 @@ public class VectorHandler implements IDataHandler {
     }
 
     @Override
-    public Object encrypt(IProvideEncryptionForObject context, Object data) throws NotPossibleToHandleDataTypeException, IOException, InvalidCipherException {
+    public Object encrypt(IProvideEncryptionForObject context, Object data) throws NotPossibleToHandleDataTypeException, IOException, InvalidCipherException, NotImplementedException {
         var content = (Vector<?>)data;
         var result = new Vector<>();
 

--- a/lib/src/main/java/com/evervault/exceptions/Asn1EncodingException.java
+++ b/lib/src/main/java/com/evervault/exceptions/Asn1EncodingException.java
@@ -1,0 +1,9 @@
+package com.evervault.exceptions;
+
+public class Asn1EncodingException extends Exception{
+    private static final String ERROR_MESSAGE = "ASN1 encoding error";
+
+    public Asn1EncodingException() {
+        super(ERROR_MESSAGE);
+    }
+}

--- a/lib/src/main/java/com/evervault/models/Secp256r1Constants.java
+++ b/lib/src/main/java/com/evervault/models/Secp256r1Constants.java
@@ -1,0 +1,11 @@
+package com.evervault.models;
+
+public class Secp256r1Constants {
+    public final String p = "FF FF FF FF 00 00 00 01 00 00 00 00 00 00 00 00 00 00 00 00 FF FF FF FF FF FF FF FF FF FF FF FF";
+    public final String a = "FF FF FF FF 00 00 00 01 00 00 00 00 00 00 00 00 00 00 00 00 FF FF FF FF FF FF FF FF FF FF FF FC";
+    public final String b = "5A C6 35 D8 AA 3A 93 E7 B3 EB BD 55 76 98 86 BC 65 1D 06 B0 CC 53 B0 F6 3B CE 3C 3E 27 D2 60 4B";
+    public final String seed = "C4 9D 36 08 86 E7 04 93 6A 66 78 E1 13 9D 26 B7 81 9F 7E 90";
+    public final String generator = "04 6B 17 D1 F2 E1 2C 42 47 F8 BC E6 E5 63 A4 40 F2 77 03 7D 81 2D EB 33 A0 F4 A1 39 45 D8 98 C2 96 4F E3 42 E2 FE 1A 7F 9B 8E E7 EB 4A 7C 0F 9E 16 2B CE 33 57 6B 31 5E CE CB B6 40 68 37 BF 51 F5";
+    public final String n = "FF FF FF FF 00 00 00 00 FF FF FF FF FF FF FF FF BC E6 FA AD A7 17 9E 84 F3 B9 CA C2 FC 63 25 51";
+    public final String h = "01";
+}

--- a/lib/src/main/java/com/evervault/services/ASN1Encoder.java
+++ b/lib/src/main/java/com/evervault/services/ASN1Encoder.java
@@ -1,0 +1,81 @@
+package com.evervault.services;
+
+import com.evervault.exceptions.Asn1EncodingException;
+import com.evervault.models.Secp256r1Constants;
+
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.lang.Math;
+
+public class ASN1Encoder {
+    protected final Secp256r1Constants curveConstants;
+
+    public ASN1Encoder(Secp256r1Constants curveConstants) {
+        this.curveConstants = curveConstants;
+    };
+
+    public String encode(String... arguments) throws Asn1EncodingException {
+        String type = arguments[0];
+
+        String[] hexStrings = Arrays.copyOfRange(arguments, 1, arguments.length);
+        String combinedHexStrings = String.join("", hexStrings);
+
+        String str = combinedHexStrings.replaceAll("\\s+", "").toLowerCase();
+
+        Integer len = str.length() / 2;
+        Integer lenlen = 0;
+        String hex = type;
+
+        // We can't have an odd number of hex chars
+        if (len != Math.floor(len)) {
+            throw new Asn1EncodingException();
+        }
+
+        // The first bye of any ASN.1 sequence is the type (Sequence, Integer, etc)
+        // The second byte is either the size of the value, or the size of its size
+        // 1. If the second byte is < 0x80 (128) it is considered the size
+        // 2. If it is  > 0x80 then it describes the number of bytes of the size
+        //    eg: 0x82 means the next to bytes describe the size of the value
+        // 3. The special case of exactly 0x80 is "indefinite" length (to end-of-file)
+        if (len > 127) {
+            lenlen += 1;
+            while (len > 255) {
+                lenlen += 1;
+                len = len >> 8;
+            }
+        }
+
+        if (lenlen > 0) {
+            hex += this.numToHex(0x80 + lenlen);
+        }
+
+        return hex + this.numToHex(str.length() / 2) + str; 
+    };
+
+    // The Integer type has some special rules
+    public String UINT(String... arguments) throws Asn1EncodingException {
+        String str = String.join("", arguments);
+        BigInteger first = new BigInteger(str.substring(0, 2), 16);
+
+        if (new BigInteger("80", 16).and(first).compareTo(BigInteger.ZERO) > 0) {
+            str = "00" + str;
+        };
+
+        return this.encode("02", str);
+    };
+
+    // Bit String type also has a special rule
+    public String BITSTR(String... arguments) throws Asn1EncodingException{
+        String str = String.join("", arguments);
+        // '00' is a mask of how many bits of the next byte to ignore
+        return this.encode("03", "00" + str);
+    };
+
+    public String numToHex(int d) {
+        String hexString = Integer.toHexString(d);
+        if (hexString.length() % 2 != 0) {
+            return "0" + hexString;
+        }
+        return hexString;
+    }
+}

--- a/lib/src/main/java/com/evervault/services/DEREncoder.java
+++ b/lib/src/main/java/com/evervault/services/DEREncoder.java
@@ -1,0 +1,51 @@
+package com.evervault.services;
+
+import java.util.HexFormat;
+
+import com.evervault.exceptions.Asn1EncodingException;
+import com.evervault.models.Secp256r1Constants;
+import com.evervault.utils.HexHandler;
+
+public class DEREncoder {
+    protected final Secp256r1Constants curveValues;
+
+    public DEREncoder(Secp256r1Constants constants) {
+        this.curveValues = constants;
+    }
+
+    public byte[] publicKeyToDer(byte[] decompressedPublicKey) throws Asn1EncodingException {
+        var ASN1 = new ASN1Encoder(this.curveValues);
+        String encoded = ASN1.encode(
+            "30",
+            ASN1.encode(
+                "30",
+                // 1.2.840.10045.2.1 ecPublicKey
+                // (ANSI X9.62 public key type)
+                ASN1.encode("06", "2A 86 48 CE 3D 02 01"),
+                ASN1.encode(
+                    "30",
+                    // ECParameters Version
+                    ASN1.UINT("01"),
+                    ASN1.encode(
+                        "30",
+                        // X9.62 Prime Field
+                        ASN1.encode("06", "2A 86 48 CE 3D 01 01"),
+                        ASN1.UINT(this.curveValues.p)
+                    ),
+                    ASN1.encode(
+                        "30",
+                        ASN1.encode("04", this.curveValues.a),
+                        ASN1.encode("04", this.curveValues.b),
+                        ASN1.BITSTR(this.curveValues.seed)
+                    ),
+                    // curve generate point in decompressed form
+                    ASN1.encode("04", this.curveValues.generator),
+                    ASN1.UINT(this.curveValues.n),
+                    ASN1.UINT(this.curveValues.h)
+                )
+            ),
+            ASN1.BITSTR(HexHandler.encode(decompressedPublicKey))
+        );
+        return HexFormat.of().parseHex(encoded);
+    }
+}

--- a/lib/src/main/java/com/evervault/services/DEREncoder.java
+++ b/lib/src/main/java/com/evervault/services/DEREncoder.java
@@ -1,7 +1,5 @@
 package com.evervault.services;
 
-import java.util.HexFormat;
-
 import com.evervault.exceptions.Asn1EncodingException;
 import com.evervault.models.Secp256r1Constants;
 import com.evervault.utils.HexHandler;
@@ -46,6 +44,6 @@ public class DEREncoder {
             ),
             ASN1.BITSTR(HexHandler.encode(decompressedPublicKey))
         );
-        return HexFormat.of().parseHex(encoded);
+        return HexHandler.decode(encoded);
     }
 }

--- a/lib/src/main/java/com/evervault/services/EncryptObjectService.java
+++ b/lib/src/main/java/com/evervault/services/EncryptObjectService.java
@@ -3,6 +3,7 @@ package com.evervault.services;
 import com.evervault.contracts.IDataHandler;
 import com.evervault.contracts.IProvideEncryptionForObject;
 import com.evervault.exceptions.InvalidCipherException;
+import com.evervault.exceptions.NotImplementedException;
 import com.evervault.exceptions.NotPossibleToHandleDataTypeException;
 import java.io.IOException;
 
@@ -14,7 +15,7 @@ public class EncryptObjectService implements IProvideEncryptionForObject {
     }
 
     @Override
-    public Object encrypt(Object data) throws NotPossibleToHandleDataTypeException, IOException, InvalidCipherException {
+    public Object encrypt(Object data) throws NotPossibleToHandleDataTypeException, IOException, InvalidCipherException, NotImplementedException {
         for (var handler: dataHandlers) {
             if (handler.canEncrypt(data)){
                 return handler.encrypt(this, data);

--- a/lib/src/main/java/com/evervault/services/EncryptionService.java
+++ b/lib/src/main/java/com/evervault/services/EncryptionService.java
@@ -98,8 +98,9 @@ public abstract class EncryptionService extends EncryptionServiceCommon implemen
     }
 
     @Override
-    public String encryptData(DataHeader header, byte[] generatedEcdhKey, byte[] data, byte[] sharedKey, byte[] teamPublicKey) throws InvalidCipherException, NotImplementedException {
+    public String encryptData(DataHeader header, byte[] generatedEcdhKey, byte[] data, byte[] sharedKey, PublicKey teamPublicKey) throws InvalidCipherException, NotImplementedException {
         var isNistCurve = this.isNistCurve(getCurveName());
+        var compressedTeamPublicKey = ((BCECPublicKey) teamPublicKey).getQ().getEncoded(true);
         var random = new SecureRandom();
         var iv = new byte[12];
         random.nextBytes(iv);
@@ -109,7 +110,7 @@ public abstract class EncryptionService extends EncryptionServiceCommon implemen
         if (!isNistCurve) {
             parameters = new AEADParameters(new KeyParameter(sharedKey), DEFAULT_MAC_BIT_SIZE, iv);
         } else {
-            parameters = new AEADParameters(new KeyParameter(sharedKey), DEFAULT_MAC_BIT_SIZE, iv, teamPublicKey);
+            parameters = new AEADParameters(new KeyParameter(sharedKey), DEFAULT_MAC_BIT_SIZE, iv, compressedTeamPublicKey);
         }
         cipher.init(true, parameters);
 

--- a/lib/src/main/java/com/evervault/services/EncryptionService.java
+++ b/lib/src/main/java/com/evervault/services/EncryptionService.java
@@ -2,10 +2,15 @@ package com.evervault.services;
 
 import com.evervault.contracts.*;
 import com.evervault.models.GeneratedSharedKey;
+import com.evervault.models.Secp256r1Constants;
 import com.evervault.utils.Base64Handler;
+import com.evervault.exceptions.Asn1EncodingException;
 import com.evervault.exceptions.InvalidCipherException;
 import com.evervault.exceptions.NotImplementedException;
+import com.evervault.utils.EcdhCurve;
+
 import org.bouncycastle.crypto.InvalidCipherTextException;
+import org.bouncycastle.crypto.digests.SHA256Digest;
 import org.bouncycastle.crypto.engines.AESEngine;
 import org.bouncycastle.crypto.modes.GCMBlockCipher;
 import org.bouncycastle.crypto.params.AEADParameters;
@@ -13,10 +18,12 @@ import org.bouncycastle.crypto.params.KeyParameter;
 import org.bouncycastle.jcajce.provider.asymmetric.ec.BCECPublicKey;
 import org.bouncycastle.jce.ECNamedCurveTable;
 import org.bouncycastle.jce.spec.ECPublicKeySpec;
+import com.google.common.primitives.Bytes;
 
-import javax.crypto.KeyAgreement;
 import java.security.*;
 import java.security.spec.InvalidKeySpecException;
+
+import javax.crypto.*;
 
 public abstract class EncryptionService extends EncryptionServiceCommon implements IProvideECPublicKey, IProvideSharedKey, IProvideEncryption {
     protected static final int DEFAULT_MAC_BIT_SIZE = 128;
@@ -29,6 +36,10 @@ public abstract class EncryptionService extends EncryptionServiceCommon implemen
 
     protected String getKeyAgreementAlgorithm() throws NotImplementedException {
         throw new NotImplementedException("getKeyAgreementAlgorithm");
+    }
+
+    protected boolean isNistCurve(String curveName) {
+        return EcdhCurve.SECP256R1.equalValue(curveName);
     }
 
     @Override
@@ -44,28 +55,62 @@ public abstract class EncryptionService extends EncryptionServiceCommon implemen
     }
 
     @Override
-    public GeneratedSharedKey generateSharedKeyBasedOn(PublicKey teamCagePublicKey) throws NoSuchAlgorithmException, InvalidAlgorithmParameterException, InvalidKeyException, NotImplementedException {
+    public GeneratedSharedKey generateSharedKeyBasedOn(PublicKey teamCagePublicKey) throws NoSuchAlgorithmException, InvalidAlgorithmParameterException, InvalidKeyException, NotImplementedException, Asn1EncodingException {
+        var isNistCurve = this.isNistCurve(getCurveName());
         var keyPair = generateNewKeyPair();
 
         var agreement = KeyAgreement.getInstance(getKeyAgreementAlgorithm(), provider);
         agreement.init(keyPair.getPrivate());
         agreement.doPhase(teamCagePublicKey, true);
 
-        var result = new GeneratedSharedKey();
-        result.GeneratedEcdhKey = ((BCECPublicKey) keyPair.getPublic()).getQ().getEncoded(true);
-        result.SharedKey = agreement.generateSecret();
+        var generatedPublicKey = ((BCECPublicKey) keyPair.getPublic()).getQ().getEncoded(true);
+        var secret =  agreement.generateSecret();
+        
+        if (!isNistCurve) {
+            var result = new GeneratedSharedKey();
+            result.GeneratedEcdhKey = generatedPublicKey;
+            result.SharedKey = secret;
+            return result;
+        }
 
+        byte[] padding = {0x00, 0x00, 0x00, 0x01};
+        var uncompressedKey = ((BCECPublicKey) keyPair.getPublic()).getQ().getEncoded(false);
+
+        var derEncoder = new DEREncoder(new Secp256r1Constants());
+        byte[] encodedPublicKey;
+        try {
+            encodedPublicKey = derEncoder.publicKeyToDer(uncompressedKey);
+        } catch (Exception e) {
+            throw new Asn1EncodingException();
+        };
+
+        byte[] concatSecret = Bytes.concat(secret, padding, encodedPublicKey);
+        
+        var sha256 = new SHA256Digest();
+        byte[] hash = new byte[sha256.getDigestSize()];
+        sha256.update(concatSecret, 0, concatSecret.length);
+        sha256.doFinal(hash, 0);
+    
+        var result = new GeneratedSharedKey();
+        result.SharedKey = hash;
+        result.GeneratedEcdhKey = generatedPublicKey;
         return result;
     }
 
     @Override
-    public String encryptData(DataHeader header, byte[] generatedEcdhKey, byte[] data, byte[] sharedKey) throws InvalidCipherException {
+    public String encryptData(DataHeader header, byte[] generatedEcdhKey, byte[] data, byte[] sharedKey, byte[] teamPublicKey) throws InvalidCipherException, NotImplementedException {
+        var isNistCurve = this.isNistCurve(getCurveName());
         var random = new SecureRandom();
         var iv = new byte[12];
         random.nextBytes(iv);
 
         var cipher = new GCMBlockCipher(new AESEngine());
-        var parameters = new AEADParameters(new KeyParameter(sharedKey), DEFAULT_MAC_BIT_SIZE, iv);
+        AEADParameters parameters;
+        if (!isNistCurve) {
+            parameters = new AEADParameters(new KeyParameter(sharedKey), DEFAULT_MAC_BIT_SIZE, iv);
+        } else {
+            parameters = new AEADParameters(new KeyParameter(sharedKey), DEFAULT_MAC_BIT_SIZE, iv, teamPublicKey);
+        }
         cipher.init(true, parameters);
 
         var cipherText = new byte[cipher.getOutputSize(data.length)];
@@ -78,6 +123,13 @@ public abstract class EncryptionService extends EncryptionServiceCommon implemen
             throw new InvalidCipherException(e);
         }
 
-        return encryptFormatProvider.format(header, Base64Handler.encodeBase64(iv), Base64Handler.encodeBase64(generatedEcdhKey), Base64Handler.encodeBase64(cipherText));
+        var formatted = encryptFormatProvider.format(
+            header,
+            Base64Handler.encodeBase64(iv),
+            Base64Handler.encodeBase64(generatedEcdhKey),
+            Base64Handler.encodeBase64(cipherText)
+        );
+
+        return formatted;
     }
 }

--- a/lib/src/main/java/com/evervault/services/EvervaultEncryptionService.java
+++ b/lib/src/main/java/com/evervault/services/EvervaultEncryptionService.java
@@ -5,23 +5,23 @@ import com.evervault.contracts.IProvideEncryption;
 import com.evervault.dataHandlers.*;
 
 public class EvervaultEncryptionService extends EncryptObjectService {
-    public EvervaultEncryptionService(IProvideEncryption encryptionProvider, byte[] generatedEcdhKey, byte[] sharedKey) {
+    public EvervaultEncryptionService(IProvideEncryption encryptionProvider, byte[] generatedEcdhKey, byte[] sharedKey, byte[] teamPublicKey) {
         super(new IDataHandler[] {
-                new StringDataHandler(encryptionProvider, generatedEcdhKey, sharedKey),
-                new FloatHandler(encryptionProvider, generatedEcdhKey, sharedKey),
-                new ShortHandler(encryptionProvider, generatedEcdhKey, sharedKey),
-                new BooleanHandler(encryptionProvider, generatedEcdhKey, sharedKey),
-                new IntegerHandler(encryptionProvider, generatedEcdhKey, sharedKey),
-                new DoubleHandler(encryptionProvider, generatedEcdhKey, sharedKey),
-                new LongHandler(encryptionProvider, generatedEcdhKey, sharedKey),
-                new ByteHandler(encryptionProvider, generatedEcdhKey, sharedKey),
-                new CharHandler(encryptionProvider, generatedEcdhKey, sharedKey),
+                new StringDataHandler(encryptionProvider, generatedEcdhKey, sharedKey, teamPublicKey),
+                new FloatHandler(encryptionProvider, generatedEcdhKey, sharedKey, teamPublicKey),
+                new ShortHandler(encryptionProvider, generatedEcdhKey, sharedKey, teamPublicKey),
+                new BooleanHandler(encryptionProvider, generatedEcdhKey, sharedKey, teamPublicKey),
+                new IntegerHandler(encryptionProvider, generatedEcdhKey, sharedKey, teamPublicKey),
+                new DoubleHandler(encryptionProvider, generatedEcdhKey, sharedKey, teamPublicKey),
+                new LongHandler(encryptionProvider, generatedEcdhKey, sharedKey, teamPublicKey),
+                new ByteHandler(encryptionProvider, generatedEcdhKey, sharedKey, teamPublicKey),
+                new CharHandler(encryptionProvider, generatedEcdhKey, sharedKey, teamPublicKey),
                 new VectorHandler(),
                 new MapHandler(),
                 new ArrayHandler(),
 
                 /// This has to be the last one, otherwise other structures will not work
-                new SerializableHandler(encryptionProvider, generatedEcdhKey, sharedKey)
+                new SerializableHandler(encryptionProvider, generatedEcdhKey, sharedKey, teamPublicKey)
         });
     }
 }

--- a/lib/src/main/java/com/evervault/services/EvervaultEncryptionService.java
+++ b/lib/src/main/java/com/evervault/services/EvervaultEncryptionService.java
@@ -1,11 +1,13 @@
 package com.evervault.services;
 
+import java.security.PublicKey;
+
 import com.evervault.contracts.IDataHandler;
 import com.evervault.contracts.IProvideEncryption;
 import com.evervault.dataHandlers.*;
 
 public class EvervaultEncryptionService extends EncryptObjectService {
-    public EvervaultEncryptionService(IProvideEncryption encryptionProvider, byte[] generatedEcdhKey, byte[] sharedKey, byte[] teamPublicKey) {
+    public EvervaultEncryptionService(IProvideEncryption encryptionProvider, byte[] generatedEcdhKey, byte[] sharedKey, PublicKey teamPublicKey) {
         super(new IDataHandler[] {
                 new StringDataHandler(encryptionProvider, generatedEcdhKey, sharedKey, teamPublicKey),
                 new FloatHandler(encryptionProvider, generatedEcdhKey, sharedKey, teamPublicKey),

--- a/lib/src/main/java/com/evervault/services/EvervaultService.java
+++ b/lib/src/main/java/com/evervault/services/EvervaultService.java
@@ -100,7 +100,7 @@ public abstract class EvervaultService {
 
         try {
             setupKeys(ecdhCurve);
-        } catch (HttpFailureException | InterruptedException | NoSuchAlgorithmException | InvalidKeySpecException | InvalidAlgorithmParameterException | InvalidKeyException | NotPossibleToHandleDataTypeException | MaxRetryReachedException | NoSuchProviderException | NotImplementedException | IOException e) {
+        } catch (HttpFailureException | InterruptedException | NoSuchAlgorithmException | InvalidKeySpecException | InvalidAlgorithmParameterException | InvalidKeyException | NotPossibleToHandleDataTypeException | MaxRetryReachedException | NoSuchProviderException | NotImplementedException | IOException | Asn1EncodingException e) {
             throw new EvervaultException(e);
         }
     }
@@ -113,7 +113,7 @@ public abstract class EvervaultService {
         this.encryptionProvider = encryptionProvider;
     }
 
-    private void setupKeys(EcdhCurve ecdhCurve) throws HttpFailureException, IOException, InterruptedException, NoSuchAlgorithmException, InvalidKeySpecException, InvalidAlgorithmParameterException, InvalidKeyException, NotPossibleToHandleDataTypeException, MaxRetryReachedException, NoSuchProviderException, NotImplementedException {
+    private void setupKeys(EcdhCurve ecdhCurve) throws HttpFailureException, IOException, InterruptedException, NoSuchAlgorithmException, InvalidKeySpecException, InvalidAlgorithmParameterException, InvalidKeyException, NotPossibleToHandleDataTypeException, MaxRetryReachedException, NoSuchProviderException, NotImplementedException, Asn1EncodingException {
         var teamEcdhKey = circuitBreakerProvider.execute(getCageHash, () -> cagePublicKeyFromEndpointProvider.getCagePublicKeyFromEndpoint(getEvervaultApiUrl()));
 
         teamUuid = teamEcdhKey.teamUuid;
@@ -154,7 +154,7 @@ public abstract class EvervaultService {
         System.setProperty("http.nonProxyHosts", ignoreDomains);
     }
 
-    private void generateSharedKey() throws InvalidAlgorithmParameterException, NoSuchAlgorithmException, InvalidKeyException, NotImplementedException {
+    private void generateSharedKey() throws InvalidAlgorithmParameterException, NoSuchAlgorithmException, InvalidKeyException, NotImplementedException, Asn1EncodingException {
         currentSharedKeyTimestamp = timeProvider.GetNow();
         var generated = sharedKeyProvider.generateSharedKeyBasedOn(teamKey);
 
@@ -171,7 +171,7 @@ public abstract class EvervaultService {
 
         try {
             return this.encryptionProvider.encrypt(data);
-        } catch (NotPossibleToHandleDataTypeException | IOException | InvalidCipherException e) {
+        } catch (NotPossibleToHandleDataTypeException | IOException | InvalidCipherException | NotImplementedException e) {
             throw new EvervaultException(e);
         }
     }
@@ -180,7 +180,7 @@ public abstract class EvervaultService {
         if (Duration.between(currentSharedKeyTimestamp, timeProvider.GetNow()).toMinutes() >= NEW_KEY_TIMESTAMP) {
             try {
                 generateSharedKey();
-            } catch (InvalidAlgorithmParameterException | InvalidKeyException | NoSuchAlgorithmException | NotImplementedException e) {
+            } catch (InvalidAlgorithmParameterException | InvalidKeyException | NoSuchAlgorithmException | NotImplementedException | Asn1EncodingException e) {
                 throw new EvervaultException(e);
             }
         }

--- a/lib/src/main/java/com/evervault/services/R1StdEncryptionOutputFormat.java
+++ b/lib/src/main/java/com/evervault/services/R1StdEncryptionOutputFormat.java
@@ -7,7 +7,7 @@ import com.evervault.contracts.IProvideEncryptedFormat;
 import java.nio.charset.StandardCharsets;
 
 public class R1StdEncryptionOutputFormat implements IProvideEncryptedFormat {
-    private static final String EVERVAULT_VERSION = "ORK";
+    private static final String EVERVAULT_VERSION = "NOC";
     private static final String ENCRYPTED_FIELD_FORMAT = "ev:%s%s:%s:%s:%s:$";
     private final String evervaultVersionToUse;
 

--- a/lib/src/main/java/com/evervault/utils/EcdhCurve.java
+++ b/lib/src/main/java/com/evervault/utils/EcdhCurve.java
@@ -10,4 +10,8 @@ public enum EcdhCurve {
         this.curveId = curveId;
     }
 
+    public boolean equalValue(String curveName) {
+        return this.curveId.equals(curveName);
+    }
+
 }

--- a/lib/src/main/java/com/evervault/utils/HexHandler.java
+++ b/lib/src/main/java/com/evervault/utils/HexHandler.java
@@ -30,4 +30,15 @@ public class HexHandler {
     public static String encode(byte[] byteArray) {
         return encode(byteArray, false, ByteOrder.BIG_ENDIAN);
     }
+
+    // Needed for compatibility with Java 11
+    public static byte[] decode(String s) {
+        int len = s.length();
+        byte[] data = new byte[len / 2];
+        for (int i = 0; i < len; i += 2) {
+            data[i / 2] = (byte) ((Character.digit(s.charAt(i), 16) << 4)
+                                 + Character.digit(s.charAt(i+1), 16));
+        }
+        return data;
+    }
 }

--- a/lib/src/main/java/com/evervault/utils/HexHandler.java
+++ b/lib/src/main/java/com/evervault/utils/HexHandler.java
@@ -1,0 +1,33 @@
+package com.evervault.utils;
+
+import java.nio.ByteOrder;
+
+public class HexHandler {
+    private static final char[] LOOKUP_TABLE_LOWER = new char[]{0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66};
+    private static final char[] LOOKUP_TABLE_UPPER = new char[]{0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46};
+            
+    public static String encode(byte[] byteArray, boolean upperCase, ByteOrder byteOrder) {
+
+        // our output size will be exactly 2x byte-array length
+        final char[] buffer = new char[byteArray.length * 2];
+
+        // choose lower or uppercase lookup table
+        final char[] lookup = upperCase ? LOOKUP_TABLE_UPPER : LOOKUP_TABLE_LOWER;
+
+        int index;
+        for (int i = 0; i < byteArray.length; i++) {
+            // for little endian we count from last to first
+            index = (byteOrder == ByteOrder.BIG_ENDIAN) ? i : byteArray.length - i - 1;
+            
+            // extract the upper 4 bit and look up char (0-A)
+            buffer[i << 1] = lookup[(byteArray[index] >> 4) & 0xF];
+            // extract the lower 4 bit and look up char (0-A)
+            buffer[(i << 1) + 1] = lookup[(byteArray[index] & 0xF)];
+        }
+        return new String(buffer);
+    }
+
+    public static String encode(byte[] byteArray) {
+        return encode(byteArray, false, ByteOrder.BIG_ENDIAN);
+    }
+}

--- a/lib/src/test/java/com/evervault/EncryptSetup.java
+++ b/lib/src/test/java/com/evervault/EncryptSetup.java
@@ -13,7 +13,7 @@ public class EncryptSetup {
 
     public KeyPair keyPair;
     public byte[] sharedKey;
-    public byte[] cageKey;
+    public PublicKey cageKey;
 
     public EncryptSetup() throws InvalidAlgorithmParameterException, InvalidKeyException, NoSuchAlgorithmException {
         var provider = new BouncyCastleProvider();
@@ -27,5 +27,6 @@ public class EncryptSetup {
         agreement.doPhase(keyPair.getPublic(), true);
 
         sharedKey = agreement.generateSecret();
+        cageKey = keyPair.getPublic();
     }
 }

--- a/lib/src/test/java/com/evervault/EncryptSetup.java
+++ b/lib/src/test/java/com/evervault/EncryptSetup.java
@@ -8,11 +8,12 @@ import java.security.spec.ECGenParameterSpec;
 
 public class EncryptSetup {
     private final String ALGORITHM = "EC";
-    private final String STDNAME = "secp256k1";
+    private final String STDNAME = "secp256r1";
     private final String KEYAGREEMENT_ALGORITHM = "ECDH";
 
     public KeyPair keyPair;
     public byte[] sharedKey;
+    public byte[] cageKey;
 
     public EncryptSetup() throws InvalidAlgorithmParameterException, InvalidKeyException, NoSuchAlgorithmException {
         var provider = new BouncyCastleProvider();

--- a/lib/src/test/java/com/evervault/WhenEncryptingDifferentTypesOfDataTests.java
+++ b/lib/src/test/java/com/evervault/WhenEncryptingDifferentTypesOfDataTests.java
@@ -4,6 +4,7 @@ import com.evervault.contracts.DataHeader;
 import com.evervault.contracts.IProvideEncryption;
 import com.evervault.contracts.IProvideEncryptionForObject;
 import com.evervault.exceptions.InvalidCipherException;
+import com.evervault.exceptions.NotImplementedException;
 import com.evervault.exceptions.NotPossibleToHandleDataTypeException;
 import com.evervault.services.EvervaultEncryptionService;
 import org.junit.jupiter.api.Test;
@@ -32,48 +33,48 @@ public class WhenEncryptingDifferentTypesOfDataTests {
         public IProvideEncryptionForObject encryptionService;
     }
 
-    private TestSetup getService() throws InvalidAlgorithmParameterException, NoSuchAlgorithmException, InvalidKeyException {
+    private TestSetup getService() throws InvalidAlgorithmParameterException, NoSuchAlgorithmException, InvalidKeyException, NotImplementedException {
         var setup = new EncryptSetup();
 
         var encryptionProvider = mock(IProvideEncryption.class);
 
         var testSetup = new TestSetup();
         var key = setup.keyPair.getPublic().getEncoded();
-        testSetup.encryptionService = new EvervaultEncryptionService(encryptionProvider, key, setup.sharedKey);
+        testSetup.encryptionService = new EvervaultEncryptionService(encryptionProvider, key, setup.sharedKey, setup.cageKey);
         testSetup.encryptionProvider = encryptionProvider;
 
         return testSetup;
     }
 
     @Test
-    void handlesStringCorrectly() throws InvalidAlgorithmParameterException, NoSuchAlgorithmException, InvalidKeyException, NotPossibleToHandleDataTypeException, IOException, InvalidCipherException {
+    void handlesStringCorrectly() throws NotImplementedException, InvalidAlgorithmParameterException, NoSuchAlgorithmException, InvalidKeyException, NotPossibleToHandleDataTypeException, IOException, InvalidCipherException {
         var testSetup = getService();
 
         var someString = "Foo";
         var someReturn = "Bar";
 
-        when(testSetup.encryptionProvider.encryptData(eq(DataHeader.String), any(), eq(someString.getBytes(StandardCharsets.UTF_8)), any())).thenReturn(someReturn);
+        when(testSetup.encryptionProvider.encryptData(eq(DataHeader.String), any(), eq(someString.getBytes(StandardCharsets.UTF_8)), any(), any())).thenReturn(someReturn);
 
         assert testSetup.encryptionService.encrypt(someString).equals(someReturn);
     }
 
     @Test
-    void ifNotAbleToHandleTypeThenThrows() throws InvalidAlgorithmParameterException, NoSuchAlgorithmException, InvalidKeyException {
+    void ifNotAbleToHandleTypeThenThrows() throws InvalidAlgorithmParameterException, NoSuchAlgorithmException, InvalidKeyException, NotImplementedException {
         var testSetup = getService();
 
         assertThrows(NotPossibleToHandleDataTypeException.class, () -> testSetup.encryptionService.encrypt(null));
     }
 
     @Test
-    void handlesDictionaryCorrectly() throws InvalidAlgorithmParameterException, NoSuchAlgorithmException, InvalidKeyException, NotPossibleToHandleDataTypeException, IOException, InvalidCipherException {
+    void handlesDictionaryCorrectly() throws NotImplementedException, InvalidAlgorithmParameterException, NoSuchAlgorithmException, InvalidKeyException, NotPossibleToHandleDataTypeException, IOException, InvalidCipherException {
         var testSetup = getService();
 
         var map = new HashMap<String, String>();
         map.put("Foo", "Bar");
         map.put("Ever", "Vault");
 
-        when(testSetup.encryptionProvider.encryptData(eq(DataHeader.String), any(), eq("Bar".getBytes(StandardCharsets.UTF_8)), any())).thenReturn("Foo");
-        when(testSetup.encryptionProvider.encryptData(eq(DataHeader.String), any(), eq("Vault".getBytes(StandardCharsets.UTF_8)), any())).thenReturn("Ever");
+        when(testSetup.encryptionProvider.encryptData(eq(DataHeader.String), any(), eq("Bar".getBytes(StandardCharsets.UTF_8)), any(), any())).thenReturn("Foo");
+        when(testSetup.encryptionProvider.encryptData(eq(DataHeader.String), any(), eq("Vault".getBytes(StandardCharsets.UTF_8)), any(), any())).thenReturn("Ever");
 
         var encrypted = (HashMap<String, String>) testSetup.encryptionService.encrypt(map);
 
@@ -82,31 +83,31 @@ public class WhenEncryptingDifferentTypesOfDataTests {
     }
 
     @Test
-    void handlesBooleanCorrectly() throws InvalidAlgorithmParameterException, NoSuchAlgorithmException, InvalidKeyException, NotPossibleToHandleDataTypeException, IOException, InvalidCipherException {
+    void handlesBooleanCorrectly() throws NotImplementedException, InvalidAlgorithmParameterException, NoSuchAlgorithmException, InvalidKeyException, NotPossibleToHandleDataTypeException, IOException, InvalidCipherException {
         var testSetup = getService();
 
-        when(testSetup.encryptionProvider.encryptData(eq(DataHeader.Boolean), any(), eq(new byte[]{1}), any())).thenReturn("true");
-        when(testSetup.encryptionProvider.encryptData(eq(DataHeader.Boolean), any(), eq(new byte[]{0}), any())).thenReturn("false");
+        when(testSetup.encryptionProvider.encryptData(eq(DataHeader.Boolean), any(), eq(new byte[]{1}), any(), any())).thenReturn("true");
+        when(testSetup.encryptionProvider.encryptData(eq(DataHeader.Boolean), any(), eq(new byte[]{0}), any(), any())).thenReturn("false");
 
         assert "true".equals(testSetup.encryptionService.encrypt(true));
         assert "false".equals(testSetup.encryptionService.encrypt(false));
     }
 
     @Test
-    void handlesIntegerCorrectly() throws InvalidAlgorithmParameterException, NoSuchAlgorithmException, InvalidKeyException, NotPossibleToHandleDataTypeException, IOException, InvalidCipherException {
+    void handlesIntegerCorrectly() throws NotImplementedException, InvalidAlgorithmParameterException, NoSuchAlgorithmException, InvalidKeyException, NotPossibleToHandleDataTypeException, IOException, InvalidCipherException {
         var testSetup = getService();
 
         int someInt = 132;
         var bytes = ByteBuffer.allocate(4).putInt(someInt).array();
         final String result = "onetwothree";
 
-        when(testSetup.encryptionProvider.encryptData(eq(DataHeader.Number), any(), eq(bytes), any())).thenReturn(result);
+        when(testSetup.encryptionProvider.encryptData(eq(DataHeader.Number), any(), eq(bytes), any(), any())).thenReturn(result);
 
         assert result.equals(testSetup.encryptionService.encrypt(someInt));
     }
 
     @Test
-    void handlesByteCorrectly() throws InvalidAlgorithmParameterException, NoSuchAlgorithmException, InvalidKeyException, NotPossibleToHandleDataTypeException, IOException, InvalidCipherException {
+    void handlesByteCorrectly() throws NotImplementedException, InvalidAlgorithmParameterException, NoSuchAlgorithmException, InvalidKeyException, NotPossibleToHandleDataTypeException, IOException, InvalidCipherException {
         var testSetup = getService();
 
         final byte someByte = 1;
@@ -114,72 +115,72 @@ public class WhenEncryptingDifferentTypesOfDataTests {
 
         var bytes = ByteBuffer.allocate(1).put(someByte).array();
 
-        when(testSetup.encryptionProvider.encryptData(eq(DataHeader.String), any(), eq(bytes), any())).thenReturn(result);
+        when(testSetup.encryptionProvider.encryptData(eq(DataHeader.String), any(), eq(bytes), any(), any())).thenReturn(result);
 
         assert result.equals(testSetup.encryptionService.encrypt(someByte));
     }
 
     @Test
-    void handlesShortCorrectly() throws InvalidAlgorithmParameterException, NoSuchAlgorithmException, InvalidKeyException, NotPossibleToHandleDataTypeException, IOException, InvalidCipherException {
+    void handlesShortCorrectly() throws NotImplementedException, InvalidAlgorithmParameterException, NoSuchAlgorithmException, InvalidKeyException, NotPossibleToHandleDataTypeException, IOException, InvalidCipherException {
         var testSetup = getService();
 
         final short someShort = 1;
         final String result = "onetwothree";
         var bytes = ByteBuffer.allocate(2).putShort(someShort).array();
 
-        when(testSetup.encryptionProvider.encryptData(eq(DataHeader.Number), any(), eq(bytes), any())).thenReturn(result);
+        when(testSetup.encryptionProvider.encryptData(eq(DataHeader.Number), any(), eq(bytes), any(), any())).thenReturn(result);
 
         assert result.equals(testSetup.encryptionService.encrypt(someShort));
     }
 
     @Test
-    void handlesLongCorrectly() throws InvalidAlgorithmParameterException, NoSuchAlgorithmException, InvalidKeyException, NotPossibleToHandleDataTypeException, IOException, InvalidCipherException {
+    void handlesLongCorrectly() throws NotImplementedException, InvalidAlgorithmParameterException, NoSuchAlgorithmException, InvalidKeyException, NotPossibleToHandleDataTypeException, IOException, InvalidCipherException {
         var testSetup = getService();
 
         final long someLong = 1;
         final String result = "onetwothree";
         var bytes = ByteBuffer.allocate(8).putLong(someLong).array();
 
-        when(testSetup.encryptionProvider.encryptData(eq(DataHeader.Number), any(), eq(bytes), any())).thenReturn(result);
+        when(testSetup.encryptionProvider.encryptData(eq(DataHeader.Number), any(), eq(bytes), any(), any())).thenReturn(result);
 
         assert result.equals(testSetup.encryptionService.encrypt(someLong));
     }
 
     @Test
-    void handlesFloatCorrectly() throws InvalidAlgorithmParameterException, NoSuchAlgorithmException, InvalidKeyException, NotPossibleToHandleDataTypeException, IOException, InvalidCipherException {
+    void handlesFloatCorrectly() throws NotImplementedException, InvalidAlgorithmParameterException, NoSuchAlgorithmException, InvalidKeyException, NotPossibleToHandleDataTypeException, IOException, InvalidCipherException {
         var testSetup = getService();
 
         final float someFloat = 1;
         final String result = "onetwothree";
         var bytes = ByteBuffer.allocate(4).putFloat(someFloat).array();
 
-        when(testSetup.encryptionProvider.encryptData(eq(DataHeader.Number), any(), eq(bytes), any())).thenReturn(result);
+        when(testSetup.encryptionProvider.encryptData(eq(DataHeader.Number), any(), eq(bytes), any(), any())).thenReturn(result);
 
         assert result.equals(testSetup.encryptionService.encrypt(someFloat));
     }
 
     @Test
-    void handlesDoubleCorrectly() throws InvalidAlgorithmParameterException, NoSuchAlgorithmException, InvalidKeyException, NotPossibleToHandleDataTypeException, IOException, InvalidCipherException {
+    void handlesDoubleCorrectly() throws NotImplementedException, InvalidAlgorithmParameterException, NoSuchAlgorithmException, InvalidKeyException, NotPossibleToHandleDataTypeException, IOException, InvalidCipherException {
         var testSetup = getService();
 
         final double someDouble = 1;
         final String result = "onetwothree";
         var bytes = ByteBuffer.allocate(8).putDouble(someDouble).array();
 
-        when(testSetup.encryptionProvider.encryptData(eq(DataHeader.Number), any(), eq(bytes), any())).thenReturn(result);
+        when(testSetup.encryptionProvider.encryptData(eq(DataHeader.Number), any(), eq(bytes), any(), any())).thenReturn(result);
 
         assert result.equals(testSetup.encryptionService.encrypt(someDouble));
     }
 
     @Test
-    void handlesCharCorrectly() throws InvalidAlgorithmParameterException, NoSuchAlgorithmException, InvalidKeyException, NotPossibleToHandleDataTypeException, IOException, InvalidCipherException {
+    void handlesCharCorrectly() throws NotImplementedException, InvalidAlgorithmParameterException, NoSuchAlgorithmException, InvalidKeyException, NotPossibleToHandleDataTypeException, IOException, InvalidCipherException {
         var testSetup = getService();
 
         final char someChar = 'a';
         final String result = "onetwothree";
         var bytes = ByteBuffer.allocate(2).putChar(someChar).array();
 
-        when(testSetup.encryptionProvider.encryptData(eq(DataHeader.String), any(), eq(bytes), any())).thenReturn(result);
+        when(testSetup.encryptionProvider.encryptData(eq(DataHeader.String), any(), eq(bytes), any(), any())).thenReturn(result);
 
         var content = (String)testSetup.encryptionService.encrypt(someChar);
 
@@ -187,7 +188,7 @@ public class WhenEncryptingDifferentTypesOfDataTests {
     }
 
     @Test
-    void handlesVectorCorrectly() throws InvalidAlgorithmParameterException, NoSuchAlgorithmException, InvalidKeyException, NotPossibleToHandleDataTypeException, IOException, InvalidCipherException {
+    void handlesVectorCorrectly() throws NotImplementedException, InvalidAlgorithmParameterException, NoSuchAlgorithmException, InvalidKeyException, NotPossibleToHandleDataTypeException, IOException, InvalidCipherException {
         var testSetup = getService();
 
         var list = new Vector<Integer>();
@@ -199,8 +200,8 @@ public class WhenEncryptingDifferentTypesOfDataTests {
         final var firstTrans = "one";
         final var secTrans = "two";
 
-        when(testSetup.encryptionProvider.encryptData(eq(DataHeader.Number), any(), eq(bytesFirstItem), any())).thenReturn(firstTrans);
-        when(testSetup.encryptionProvider.encryptData(eq(DataHeader.Number), any(), eq(bytesSecondItem), any())).thenReturn(secTrans);
+        when(testSetup.encryptionProvider.encryptData(eq(DataHeader.Number), any(), eq(bytesFirstItem), any(), any())).thenReturn(firstTrans);
+        when(testSetup.encryptionProvider.encryptData(eq(DataHeader.Number), any(), eq(bytesSecondItem), any(), any())).thenReturn(secTrans);
 
         var result = (Vector<String>)testSetup.encryptionService.encrypt(list);
 
@@ -220,7 +221,7 @@ public class WhenEncryptingDifferentTypesOfDataTests {
     }
 
     @Test
-    void handlesCustomClass() throws InvalidAlgorithmParameterException, NoSuchAlgorithmException, InvalidKeyException, IOException, NotPossibleToHandleDataTypeException, InvalidCipherException {
+    void handlesCustomClass() throws NotImplementedException, InvalidAlgorithmParameterException, NoSuchAlgorithmException, InvalidKeyException, IOException, NotPossibleToHandleDataTypeException, InvalidCipherException {
         var testSetup = getService();
 
         var someInstance = new SomeClass();
@@ -231,7 +232,7 @@ public class WhenEncryptingDifferentTypesOfDataTests {
         objectOutputStream.writeObject(someInstance);
         var byteArray = outputStream.toByteArray();
 
-        when(testSetup.encryptionProvider.encryptData(eq(DataHeader.String), any(), eq(byteArray), any())).thenReturn("Bar");
+        when(testSetup.encryptionProvider.encryptData(eq(DataHeader.String), any(), eq(byteArray), any(), any())).thenReturn("Bar");
 
         var encrypted = testSetup.encryptionService.encrypt(someInstance);
 
@@ -239,7 +240,7 @@ public class WhenEncryptingDifferentTypesOfDataTests {
     }
 
     @Test
-    void handlesArrayCorrectly() throws NotPossibleToHandleDataTypeException, InvalidAlgorithmParameterException, NoSuchAlgorithmException, InvalidKeyException, IOException, InvalidCipherException {
+    void handlesArrayCorrectly() throws NotImplementedException, NotPossibleToHandleDataTypeException, InvalidAlgorithmParameterException, NoSuchAlgorithmException, InvalidKeyException, IOException, InvalidCipherException {
         var testSetup = getService();
 
         var sampleArray = new String[]{
@@ -247,8 +248,8 @@ public class WhenEncryptingDifferentTypesOfDataTests {
                 "Ever"
         };
 
-        when(testSetup.encryptionProvider.encryptData(any(), any(), eq("Foo".getBytes(StandardCharsets.UTF_8)), any())).thenReturn("Bar");
-        when(testSetup.encryptionProvider.encryptData(any(), any(), eq("Ever".getBytes(StandardCharsets.UTF_8)), any())).thenReturn("Vault");
+        when(testSetup.encryptionProvider.encryptData(any(), any(), eq("Foo".getBytes(StandardCharsets.UTF_8)), any(), any())).thenReturn("Bar");
+        when(testSetup.encryptionProvider.encryptData(any(), any(), eq("Ever".getBytes(StandardCharsets.UTF_8)), any(), any())).thenReturn("Vault");
 
         var encrypted = (Object[])testSetup.encryptionService.encrypt(sampleArray);
 

--- a/lib/src/test/java/com/evervault/WhenUsingApisEncryptionTests.java
+++ b/lib/src/test/java/com/evervault/WhenUsingApisEncryptionTests.java
@@ -4,6 +4,7 @@
 package com.evervault;
 
 import com.evervault.contracts.*;
+import com.evervault.exceptions.Asn1EncodingException;
 import com.evervault.exceptions.EvervaultException;
 import com.evervault.exceptions.HttpFailureException;
 import com.evervault.exceptions.NotImplementedException;
@@ -71,7 +72,7 @@ class WhenUsingApisEncryptionTests {
     }
 
     @Test
-    void creatingANewServiceDoesNotThrow() throws HttpFailureException, InvalidAlgorithmParameterException, IOException, NoSuchAlgorithmException, InvalidKeyException, InterruptedException, NotImplementedException, EvervaultException {
+    void creatingANewServiceDoesNotThrow() throws Asn1EncodingException, HttpFailureException, InvalidAlgorithmParameterException, IOException, NoSuchAlgorithmException, InvalidKeyException, InterruptedException, NotImplementedException, EvervaultException {
         var cagePublicKey = new CagePublicKey();
         cagePublicKey.ecdhKey = "teamEcdhKey";
         cagePublicKey.key = "key";
@@ -89,7 +90,7 @@ class WhenUsingApisEncryptionTests {
     }
 
     @Test
-    void newKeyMustBeGeneratedIf15MinutesHavePassed() throws HttpFailureException, IOException, InterruptedException, InvalidAlgorithmParameterException, NoSuchAlgorithmException, InvalidKeyException, NotImplementedException, EvervaultException {
+    void newKeyMustBeGeneratedIf15MinutesHavePassed() throws Asn1EncodingException, HttpFailureException, IOException, InterruptedException, InvalidAlgorithmParameterException, NoSuchAlgorithmException, InvalidKeyException, NotImplementedException, EvervaultException {
         var cagePublicKey = new CagePublicKey();
         cagePublicKey.ecdhKey = "teamEcdhKey";
         cagePublicKey.key = "key";
@@ -123,7 +124,7 @@ class WhenUsingApisEncryptionTests {
     }
 
     @Test
-    void tryingToEncryptNullThrows() throws HttpFailureException, InvalidAlgorithmParameterException, IOException, NoSuchAlgorithmException, InvalidKeyException, InterruptedException, NotImplementedException, EvervaultException {
+    void tryingToEncryptNullThrows() throws Asn1EncodingException, HttpFailureException, InvalidAlgorithmParameterException, IOException, NoSuchAlgorithmException, InvalidKeyException, InterruptedException, NotImplementedException, EvervaultException {
         var cagePublicKey = new CagePublicKey();
         cagePublicKey.ecdhKey = "teamEcdhKey";
         cagePublicKey.key = "key";

--- a/lib/src/test/java/com/evervault/WhenUsingApisRunCageTests.java
+++ b/lib/src/test/java/com/evervault/WhenUsingApisRunCageTests.java
@@ -69,7 +69,7 @@ public class WhenUsingApisRunCageTests {
     }
 
     @Test
-    void callingToRunCageReturnsTheHttpContent() throws HttpFailureException, IOException, InterruptedException, InvalidAlgorithmParameterException, NoSuchAlgorithmException, InvalidKeySpecException, InvalidKeyException, NotPossibleToHandleDataTypeException, InvalidCipherTextException, MaxRetryReachedException, NoSuchProviderException, NotImplementedException, EvervaultException {
+    void callingToRunCageReturnsTheHttpContent() throws Asn1EncodingException, HttpFailureException, IOException, InterruptedException, InvalidAlgorithmParameterException, NoSuchAlgorithmException, InvalidKeySpecException, InvalidKeyException, NotPossibleToHandleDataTypeException, InvalidCipherTextException, MaxRetryReachedException, NoSuchProviderException, NotImplementedException, EvervaultException {
         var cagePublicKey = new CagePublicKey();
         cagePublicKey.ecdhKey = "teamEcdhKey";
         cagePublicKey.key = "key";
@@ -96,7 +96,7 @@ public class WhenUsingApisRunCageTests {
     }
 
     @Test
-    void nullParameterThrows() throws HttpFailureException, IOException, InterruptedException, InvalidAlgorithmParameterException, NoSuchAlgorithmException, InvalidKeyException, NotImplementedException, EvervaultException {
+    void nullParameterThrows() throws Asn1EncodingException, HttpFailureException, IOException, InterruptedException, InvalidAlgorithmParameterException, NoSuchAlgorithmException, InvalidKeyException, NotImplementedException, EvervaultException {
         var cagePublicKey = new CagePublicKey();
         cagePublicKey.ecdhKey = "teamEcdhKey";
         cagePublicKey.key = "key";
@@ -123,7 +123,7 @@ public class WhenUsingApisRunCageTests {
     }
 
     @Test
-    void providerNotSetThrows() throws HttpFailureException, IOException, InterruptedException, InvalidAlgorithmParameterException, NoSuchAlgorithmException, InvalidKeyException, NotImplementedException {
+    void providerNotSetThrows() throws Asn1EncodingException, HttpFailureException, IOException, InterruptedException, InvalidAlgorithmParameterException, NoSuchAlgorithmException, InvalidKeyException, NotImplementedException {
         var cagePublicKey = new CagePublicKey();
         cagePublicKey.ecdhKey = "teamEcdhKey";
         cagePublicKey.key = "key";

--- a/lib/src/test/java/com/evervault/WhenUsingEncryptionServiceTests.java
+++ b/lib/src/test/java/com/evervault/WhenUsingEncryptionServiceTests.java
@@ -2,6 +2,7 @@ package com.evervault;
 
 import com.evervault.contracts.DataHeader;
 import com.evervault.contracts.IProvideEncryptedFormat;
+import com.evervault.exceptions.Asn1EncodingException;
 import com.evervault.exceptions.InvalidCipherException;
 import com.evervault.exceptions.NotImplementedException;
 import com.evervault.services.EncryptionService;
@@ -80,13 +81,13 @@ public final class WhenUsingEncryptionServiceTests {
     }
 
     @Test
-    void generateSharedKeyWithDecodedStringDoesNotThrow() throws NoSuchAlgorithmException, InvalidKeySpecException, InvalidAlgorithmParameterException, InvalidKeyException, NotImplementedException {
+    void generateSharedKeyWithDecodedStringDoesNotThrow() throws Asn1EncodingException, NoSuchAlgorithmException, InvalidKeySpecException, InvalidAlgorithmParameterException, InvalidKeyException, NotImplementedException {
         var publicKey = service.getEllipticCurvePublicKeyFrom(KeySample);
         service.generateSharedKeyBasedOn(publicKey);
     }
 
     @Test
-    void generateSharedKeyDoesNotThrow() throws InvalidAlgorithmParameterException, NoSuchAlgorithmException, InvalidKeyException, NotImplementedException {
+    void generateSharedKeyDoesNotThrow() throws Asn1EncodingException, InvalidAlgorithmParameterException, NoSuchAlgorithmException, InvalidKeyException, NotImplementedException {
         var provider = new BouncyCastleProvider();
         var keyPairGenerator = KeyPairGenerator.getInstance(ALGORITHM_TO_MATCH, provider);
         var genParameter = new ECGenParameterSpec(SECP256K1_NAME);
@@ -98,17 +99,17 @@ public final class WhenUsingEncryptionServiceTests {
     }
 
     @Test
-    void encryptStringReturnsOutputOfFormat() throws NoSuchAlgorithmException, InvalidAlgorithmParameterException, InvalidKeyException, InvalidCipherException {
+    void encryptStringReturnsOutputOfFormat() throws NotImplementedException, NoSuchAlgorithmException, InvalidAlgorithmParameterException, InvalidKeyException, InvalidCipherException {
         var setup = new EncryptSetup();
         final String result = "Foo";
 
         when(encryptFormatProvider.format(any(), any(), any(), any())).thenReturn(result);
 
-        assert service.encryptData(DataHeader.String, setup.keyPair.getPublic().getEncoded(), "SomeData".getBytes(StandardCharsets.UTF_8), setup.sharedKey).equals(result);
+        assert service.encryptData(DataHeader.String, setup.keyPair.getPublic().getEncoded(), "SomeData".getBytes(StandardCharsets.UTF_8), setup.sharedKey, setup.cageKey).equals(result);
     }
 
     @Test
-    void encryptStringProvidesCorrectContent() throws InvalidAlgorithmParameterException, NoSuchAlgorithmException, InvalidKeyException, InvalidCipherException {
+    void encryptStringProvidesCorrectContent() throws NotImplementedException, InvalidAlgorithmParameterException, NoSuchAlgorithmException, InvalidKeyException, InvalidCipherException {
         final String result = "Foo";
 
         var setup = new EncryptSetup();
@@ -119,7 +120,7 @@ public final class WhenUsingEncryptionServiceTests {
 
         when(encryptFormatProvider.format(any(), any(), any(), any())).thenReturn(result);
 
-        service.encryptData(DataHeader.String, setup.keyPair.getPublic().getEncoded(), "SomeData".getBytes(StandardCharsets.UTF_8), setup.sharedKey);
+        service.encryptData(DataHeader.String, setup.keyPair.getPublic().getEncoded(), "SomeData".getBytes(StandardCharsets.UTF_8), setup.sharedKey, setup.cageKey);
 
         verify(encryptFormatProvider, times(1)).format(dataHeaderTypeCapture.capture(), ivCapture.capture(), publicKeyCapture.capture(), encryptedPayloadCapture.capture());
 

--- a/lib/src/test/java/com/evervault/WhenUsingEncryptionServiceTests.java
+++ b/lib/src/test/java/com/evervault/WhenUsingEncryptionServiceTests.java
@@ -102,7 +102,7 @@ public final class WhenUsingEncryptionServiceTests {
     void encryptStringReturnsOutputOfFormat() throws NotImplementedException, NoSuchAlgorithmException, InvalidAlgorithmParameterException, InvalidKeyException, InvalidCipherException {
         var setup = new EncryptSetup();
         final String result = "Foo";
-
+        System.out.println(setup.cageKey);
         when(encryptFormatProvider.format(any(), any(), any(), any())).thenReturn(result);
 
         assert service.encryptData(DataHeader.String, setup.keyPair.getPublic().getEncoded(), "SomeData".getBytes(StandardCharsets.UTF_8), setup.sharedKey, setup.cageKey).equals(result);

--- a/lib/src/test/java/com/evervault/WhenUsingR1EncryptionOutputFormatTests.java
+++ b/lib/src/test/java/com/evervault/WhenUsingR1EncryptionOutputFormatTests.java
@@ -12,7 +12,7 @@ import java.util.stream.Stream;
 
 public class WhenUsingR1EncryptionOutputFormatTests {
     private final static R1StdEncryptionOutputFormat std = new R1StdEncryptionOutputFormat();
-    private final static String everVaultVersionToUse = new String(Base64.getEncoder().encode("ORK".getBytes(StandardCharsets.UTF_8)), StandardCharsets.US_ASCII);
+    private final static String everVaultVersionToUse = new String(Base64.getEncoder().encode("NOC".getBytes(StandardCharsets.UTF_8)), StandardCharsets.US_ASCII);
 
     @ParameterizedTest
     @MethodSource("formattingParameters")


### PR DESCRIPTION
# Why

- Add KDF when deriving shared secret for NIST curve
- Add AAD when encrypting data with NIST curve.

### Commit Messages

We use [semantic-release](https://github.com/semantic-release/semantic-release#how-does-it-work) for deployments. If one of your commits should be deployed, ensure the commit message is in the format corresponding to the correct release type. This can also be done in a squash commit.

Note: breaking changes should always use the `BREAKING CHANGE:` commit message format.
