### PR TITLE
[SCL-160] Update to make apache client easier to turn on proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,17 +64,23 @@ curl https://ca.evervault.com --output evervault-ca.cert
 sudo keytool -import -alias evervault-ca -file evervault-ca.cert -keystore <path/to/jdk/cacerts>
 ```
 
-#### Apache HTTP Client
+#### Apache Closeable HTTP Client
 
-Apache HTTP Client uses two extra JVM settings to authenticate with the proxy. When the Evervault Java SDK is initialised with intercept enabled, it sets these settings.
+The Apache Closeable HTTP Client requires the proxy and credentials to be explicitly set. When initialising your http client, you will need to get the CredentialsProvider from the Evervault SDK and the host from the Evervault ProxySystemSettings class.
 
 ```java
-// Note This is done automatically when you setup the Evervault SDK
+// Import ProxySettings for setting proxy host
+import com.evervault.utils.ProxySystemSettings;
 
-System.setProperty("https.proxyUser", user);
-System.setProperty("https.proxyPassword", password);
-System.setProperty("http.proxyUser", user);
-System.setProperty("http.proxyPassword", password);
+// Initialise Evervault SDK
+var evervault = new Evervault(getEnvironmentApiKey()
+        
+// Build httpClient with proxy
+CloseableHttpClient httpClient = HttpClientBuilder
+    .create()
+    .setProxy(ProxySystemSettings.PROXY_HOST)
+    .setDefaultCredentialsProvider(evervault.getEvervaultProxyCredentials())
+    .build();
 ```
 
 #### Java 11 Client
@@ -204,3 +210,7 @@ void encryptAndRun() throws EvervaultException {
 * Add KDF when deriving shared secret
 
 * Add AAD when encrypting with Secp256r1 curve
+
+### 2.0.7
+
+* Add helper methods for initialising Apache `CloseableHttpClient` with proxy.

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The Apache Closeable HTTP Client requires the proxy and credentials to be explic
 import com.evervault.utils.ProxySystemSettings;
 
 // Initialise Evervault SDK
-var evervault = new Evervault(getEnvironmentApiKey()
+var evervault = new Evervault(getEnvironmentApiKey())
         
 // Build httpClient with proxy
 CloseableHttpClient httpClient = HttpClientBuilder

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Our Java SDK is distributed via [maven](https://search.maven.org/artifact/com.ev
 
 ### Gradle
 ```sh
-implementation 'com.evervault:lib:2.0.6'
+implementation 'com.evervault:lib:2.0.7'
 ```
 
 ### Maven
@@ -38,7 +38,7 @@ implementation 'com.evervault:lib:2.0.6'
 <dependency>
   <groupId>com.evervault</groupId>
   <artifactId>lib</artifactId>
-  <version>2.0.6</version>
+  <version>2.0.7</version>
 </dependency>
 ```
 

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -37,6 +37,8 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.8.9'
     implementation 'com.google.guava:guava:11.0.2'
     implementation group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: '1.70'
+    implementation group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.2'
+
 }
 
 java {
@@ -53,6 +55,7 @@ testing {
             dependencies {
                 implementation project
                 implementation group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: '1.70'
+                implementation group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.2'
             }
         }
     }

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group 'com.evervault'
-version '2.0.6'
+version '2.0.7'
 
 repositories {
     mavenCentral()

--- a/lib/src/integrationTests/java/com/evervault/WhenUsingApiAgainstRealEnvironmentTests.java
+++ b/lib/src/integrationTests/java/com/evervault/WhenUsingApiAgainstRealEnvironmentTests.java
@@ -231,13 +231,11 @@ public class WhenUsingApiAgainstRealEnvironmentTests {
                 .setConnectionRequestTimeout(60 * 1000)
                 .setSocketTimeout(60 * 1000).build();
 
-        HttpHost proxy = new HttpHost("strict.relay.evervault.io", 8443);
-
         CloseableHttpClient httpClient = HttpClientBuilder
                 .create()
                 .setSSLContext(getSSLContextTrustAny())
                 .setDefaultRequestConfig(config)
-                .setProxy(proxy)
+                .setProxy(ProxySystemSettings.PROXY_HOST)
                 .setDefaultCredentialsProvider(evervault.getEvervaultProxyCredentials())
                 .build();
 
@@ -253,6 +251,7 @@ public class WhenUsingApiAgainstRealEnvironmentTests {
         httpPost.setEntity(new StringEntity(msg));
         CloseableHttpResponse response = httpClient.execute(httpPost);
 
+        httpClient.close();
         Header[] headers = response.getHeaders("x-evervault-ctx");
         assert headers.length > 0;
     }

--- a/lib/src/integrationTests/java/com/evervault/WhenUsingApiAgainstRealEnvironmentTests.java
+++ b/lib/src/integrationTests/java/com/evervault/WhenUsingApiAgainstRealEnvironmentTests.java
@@ -2,6 +2,17 @@ package com.evervault;
 
 import com.evervault.exceptions.*;
 import com.evervault.utils.EcdhCurve;
+import com.evervault.utils.ProxySystemSettings;
+import org.apache.http.Header;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpHost;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.util.EntityUtils;
 import org.bouncycastle.crypto.InvalidCipherTextException;
 import org.bouncycastle.crypto.engines.AESEngine;
 import org.bouncycastle.crypto.modes.GCMBlockCipher;
@@ -9,12 +20,17 @@ import org.bouncycastle.crypto.params.AEADParameters;
 import org.bouncycastle.crypto.params.KeyParameter;
 import org.junit.jupiter.api.Test;
 
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
 import java.io.IOException;
+import java.net.Authenticator;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
-import java.security.InvalidAlgorithmParameterException;
-import java.security.InvalidKeyException;
-import java.security.NoSuchAlgorithmException;
-import java.security.NoSuchProviderException;
+import java.security.*;
 import java.security.spec.InvalidKeySpecException;
 import java.util.Base64;
 
@@ -34,6 +50,36 @@ public class WhenUsingApiAgainstRealEnvironmentTests {
             cageName  = DEFAULT_CAGE_NAME;
         }
     }
+
+    public SSLContext getSSLContextTrustAny() throws KeyManagementException, NoSuchAlgorithmException {
+        TrustManager[] trustAllCerts = new TrustManager[]{
+                new X509TrustManager() {
+                    public java.security.cert.X509Certificate[] getAcceptedIssuers() {
+                        return null;
+                    }
+                    public void checkClientTrusted(
+                            java.security.cert.X509Certificate[] certs, String authType) {
+                    }
+                    public void checkServerTrusted(
+                            java.security.cert.X509Certificate[] certs, String authType) {
+                    }
+                }
+        };
+
+        SSLContext sslContext = SSLContext.getInstance("TLS");
+        sslContext.init(null, trustAllCerts, new SecureRandom());
+        return sslContext;
+    };
+
+    public String getPayloadWithEncryptedString(Object encryptedString) {
+        String msg = "  \"payment\": {\n" +
+                "    \"type\": \"visa\",\n" +
+                "    \"cardholderName\": \"Claude Shannon\",\n" +
+                "    \"cardNumber\": \""+ encryptedString + "\",\n" +
+                "    \"expYear\": \"23\"\n" +
+                "  },";
+        return msg;
+    };
 
     public String getEnvironmentApiKey() {
         return System.getenv(ENV_API_KEY);
@@ -55,7 +101,7 @@ public class WhenUsingApiAgainstRealEnvironmentTests {
     @Test
     void encryptSomeDataCorrectly() throws EvervaultException {
         final String someDataToEncrypt = "Foo";
-
+        System.setProperty(ProxySystemSettings.PROXY_DISABLED_SCHEMES_KEY, ProxySystemSettings.PROXY_DISABLED_SCHEMES_VALUE);
         var evervault = new Evervault(getEnvironmentApiKey());
 
         var result = (String) evervault.encrypt(someDataToEncrypt);
@@ -82,6 +128,7 @@ public class WhenUsingApiAgainstRealEnvironmentTests {
 
     @Test
     void encryptAndRun() throws EvervaultException {
+        System.setProperty(ProxySystemSettings.PROXY_DISABLED_SCHEMES_KEY, ProxySystemSettings.PROXY_DISABLED_SCHEMES_VALUE);
         var evervault = new Evervault(getEnvironmentApiKey());
         var data = Bar.createFooStructure(evervault);
         var cageResult = evervault.run(cageName, data, false, null);
@@ -91,6 +138,7 @@ public class WhenUsingApiAgainstRealEnvironmentTests {
 
     @Test
     void encryptAndRunR1Curve() throws EvervaultException {
+        System.setProperty(ProxySystemSettings.PROXY_DISABLED_SCHEMES_KEY, ProxySystemSettings.PROXY_DISABLED_SCHEMES_VALUE);
         var evervault = new Evervault(getEnvironmentApiKey(), EcdhCurve.SECP256R1);
         var data = Bar.createFooStructure(evervault);
         var cageResult = evervault.run(cageName, data, false, null);
@@ -113,6 +161,7 @@ public class WhenUsingApiAgainstRealEnvironmentTests {
 
     @Test
     void decryptDataWorksAsExpected() throws HttpFailureException, NotPossibleToHandleDataTypeException, InvalidAlgorithmParameterException, MaxRetryReachedException, IOException, NoSuchAlgorithmException, InvalidKeySpecException, InvalidKeyException, NoSuchProviderException, InterruptedException, InvalidCipherTextException, NotImplementedException, EvervaultException {
+        System.setProperty(ProxySystemSettings.PROXY_DISABLED_SCHEMES_KEY, ProxySystemSettings.PROXY_DISABLED_SCHEMES_VALUE);
         var evervault = new OwnEvervault(getEnvironmentApiKey());
 
         var bar = Bar.createFooStructure(evervault);
@@ -139,5 +188,72 @@ public class WhenUsingApiAgainstRealEnvironmentTests {
 
         var result = new String(output, StandardCharsets.US_ASCII);
         assert result.equals(Bar.NAME_CONTENT);
+    }
+
+    @Test
+    void interceptWorksThroughJava11HttpLibrary() throws HttpFailureException, NotPossibleToHandleDataTypeException, InvalidAlgorithmParameterException, MaxRetryReachedException, IOException, NoSuchAlgorithmException, InvalidKeySpecException, InvalidKeyException, NoSuchProviderException, InterruptedException, InvalidCipherTextException, NotImplementedException, EvervaultException, KeyManagementException {
+
+        System.setProperty(ProxySystemSettings.PROXY_DISABLED_SCHEMES_KEY, ProxySystemSettings.PROXY_DISABLED_SCHEMES_VALUE);
+        var evervault = new Evervault(getEnvironmentApiKey(), EcdhCurve.SECP256R1);
+
+        var encryptedString = evervault.encrypt("Secret info");
+
+        HttpClient httpClient = HttpClient.newBuilder()
+                .sslContext(getSSLContextTrustAny())
+                .authenticator(Authenticator.getDefault())
+                .build();
+
+        String uri = "https://enssc1aqsjv0g.x.pipedream.net/java-11";
+        String msg = getPayloadWithEncryptedString(encryptedString);
+
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(uri))
+                .POST(HttpRequest.BodyPublishers.ofString(msg))
+                .build();
+
+        HttpResponse<?> response = httpClient.send(request, HttpResponse.BodyHandlers.discarding());
+
+        System.out.println(response.headers());
+        assert response.headers().map().get("x-evervault-ctx") != null;
+        assert response.statusCode() == 200;
+    }
+
+    @Test
+    void interceptWorksThroughApacheHttpLibrary() throws HttpFailureException, NotPossibleToHandleDataTypeException, InvalidAlgorithmParameterException, MaxRetryReachedException, IOException, NoSuchAlgorithmException, InvalidKeySpecException, InvalidKeyException, NoSuchProviderException, InterruptedException, InvalidCipherTextException, NotImplementedException, EvervaultException, KeyManagementException {
+
+        System.setProperty(ProxySystemSettings.PROXY_DISABLED_SCHEMES_KEY, ProxySystemSettings.PROXY_DISABLED_SCHEMES_VALUE);
+        var evervault = new Evervault(getEnvironmentApiKey(), EcdhCurve.SECP256R1);
+
+        var encryptedString = evervault.encrypt("Secret info");
+
+        RequestConfig config = RequestConfig.custom()
+                .setConnectTimeout(60 * 1000)
+                .setConnectionRequestTimeout(60 * 1000)
+                .setSocketTimeout(60 * 1000).build();
+
+        HttpHost proxy = new HttpHost("strict.relay.evervault.io", 8443);
+
+        CloseableHttpClient httpClient = HttpClientBuilder
+                .create()
+                .setSSLContext(getSSLContextTrustAny())
+                .setDefaultRequestConfig(config)
+                .setProxy(proxy)
+                .setDefaultCredentialsProvider(evervault.getEvervaultProxyCredentials())
+                .build();
+
+        String uri = "https://enssc1aqsjv0g.x.pipedream.net/apache-client";
+        String msg = getPayloadWithEncryptedString(encryptedString);
+
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(uri))
+                .POST(HttpRequest.BodyPublishers.ofString(msg))
+                .build();
+
+        org.apache.http.client.methods.HttpPost httpPost = new HttpPost(uri);
+        httpPost.setEntity(new StringEntity(msg));
+        CloseableHttpResponse response = httpClient.execute(httpPost);
+
+        Header[] headers = response.getHeaders("x-evervault-ctx");
+        assert headers.length > 0;
     }
 }

--- a/lib/src/main/java/com/evervault/Evervault.java
+++ b/lib/src/main/java/com/evervault/Evervault.java
@@ -111,6 +111,7 @@ public class Evervault extends EvervaultService {
         var encryptForObject = new EvervaultEncryptionService(encryptService, this.generatedEcdhKey, this.sharedKey, this.teamKey);
 
         this.setupEncryption(encryptForObject);
+        this.setupCredentialsProvider(apiKey);
 
         if (intercept) { this.setupIntercept(apiKey); }
     }

--- a/lib/src/main/java/com/evervault/services/EvervaultService.java
+++ b/lib/src/main/java/com/evervault/services/EvervaultService.java
@@ -7,6 +7,9 @@ import com.evervault.contracts.*;
 import com.evervault.exceptions.*;
 import com.evervault.models.CageRunResult;
 import com.evervault.utils.EcdhCurve;
+import com.evervault.utils.ProxyCredentialsProvider;
+import org.apache.http.client.CredentialsProvider;
+
 import java.io.IOException;
 import java.security.*;
 import java.security.spec.InvalidKeySpecException;
@@ -21,6 +24,7 @@ public abstract class EvervaultService {
     protected IProvideEncryptionForObject encryptionProvider;
     protected IProvideCageExecution cageExecutionProvider;
     protected IProvideCircuitBreaker circuitBreakerProvider;
+    protected CredentialsProvider credentialsProvider;
 
     protected final static int NEW_KEY_TIMESTAMP = 15;
     protected final static String RELAY_PORT = "8443";
@@ -152,6 +156,15 @@ public abstract class EvervaultService {
         System.setProperty("http.proxyUser", user);
         System.setProperty("http.proxyPassword", password);
         System.setProperty("http.nonProxyHosts", ignoreDomains);
+    }
+
+    protected void setupCredentialsProvider(String apiKey) {
+        this.credentialsProvider = ProxyCredentialsProvider
+                .getEvervaultCredentialsProvider(getEvervaultRelayHost(), Integer.valueOf(RELAY_PORT), teamUuid, apiKey);
+    }
+
+    public CredentialsProvider getEvervaultProxyCredentials() {
+        return this.credentialsProvider;
     }
 
     private void generateSharedKey() throws InvalidAlgorithmParameterException, NoSuchAlgorithmException, InvalidKeyException, NotImplementedException, Asn1EncodingException {

--- a/lib/src/main/java/com/evervault/utils/ProxyCredentialsProvider.java
+++ b/lib/src/main/java/com/evervault/utils/ProxyCredentialsProvider.java
@@ -1,0 +1,20 @@
+package com.evervault.utils;
+
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+
+import java.nio.charset.StandardCharsets;
+
+public class ProxyCredentialsProvider {
+
+    public static CredentialsProvider getEvervaultCredentialsProvider(String proxyHost, Integer proxyPort, String teamUuid, String teamApiKey) {
+        AuthScope authScope= new AuthScope(proxyHost, proxyPort);
+        UsernamePasswordCredentials credentials = new UsernamePasswordCredentials(teamUuid, teamApiKey);
+
+        CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+        credentialsProvider.setCredentials(authScope, credentials);
+        return credentialsProvider;
+    }
+}

--- a/lib/src/main/java/com/evervault/utils/ProxySystemSettings.java
+++ b/lib/src/main/java/com/evervault/utils/ProxySystemSettings.java
@@ -1,6 +1,21 @@
 package com.evervault.utils;
 
+import org.apache.http.HttpHost;
+
 public class ProxySystemSettings {
     public static String PROXY_DISABLED_SCHEMES_KEY = "jdk.http.auth.tunneling.disabledSchemes";
     public static String PROXY_DISABLED_SCHEMES_VALUE = ""; //Needs to be empty as BASIC auth is disabled by default
+
+    static String getStrictHost() {
+        String DEFAULT_STRICT_HOST = "strict.relay.evervault.com";
+        String strictHost = System.getenv("EV_RELAY_HOST");
+
+        if ( strictHost == null) {
+            strictHost = DEFAULT_STRICT_HOST;
+        }
+
+        return strictHost;
+    };
+
+    public static HttpHost PROXY_HOST = new HttpHost(getStrictHost(), 8443);
 }


### PR DESCRIPTION
# Why

Apache client needs very manual steps to setup proxy atm, making it a bit simpler.

# How
Generate credentials provided in SDK and make accessible to customer.
Added tests for outbound with the Java11 Client and the Apache Client

Todo:
- [x] Update Readme
- [x] Update Docs
- [x] Move Proxy host into SDK as well so they don't have to specify it 
 Future work - programmatically trust Evervault CA