### PR TITLE
Bump Apache HttpClient Version

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Our Java SDK is distributed via [maven](https://search.maven.org/artifact/com.ev
 
 ### Gradle
 ```sh
-implementation 'com.evervault:lib:2.0.7'
+implementation 'com.evervault:lib:2.0.8'
 ```
 
 ### Maven
@@ -38,7 +38,7 @@ implementation 'com.evervault:lib:2.0.7'
 <dependency>
   <groupId>com.evervault</groupId>
   <artifactId>lib</artifactId>
-  <version>2.0.7</version>
+  <version>2.0.8</version>
 </dependency>
 ```
 
@@ -214,3 +214,7 @@ void encryptAndRun() throws EvervaultException {
 ### 2.0.7
 
 * Add helper methods for initialising Apache `CloseableHttpClient` with proxy.
+
+### 2.0.8
+
+* Bump Apache version to 4.5.13 to handle `CVE-2020-13956`

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group 'com.evervault'
-version '2.0.7'
+version '2.0.8'
 
 repositories {
     mavenCentral()
@@ -37,7 +37,7 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.8.9'
     implementation 'com.google.guava:guava:11.0.2'
     implementation group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: '1.70'
-    implementation group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.2'
+    implementation group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.13'
 
 }
 
@@ -55,7 +55,7 @@ testing {
             dependencies {
                 implementation project
                 implementation group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: '1.70'
-                implementation group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.2'
+                implementation group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.13'
             }
         }
     }


### PR DESCRIPTION
# Why
There was a [CVE](https://ossindex.sonatype.org/vulnerability/c0ed9602-d5c5-4c45-af48-c757161879ee?component-type=maven&component-name=org.apache.httpcomponents.httpclient&utm_source=ossindex-client&utm_medium=integration&utm_content=1.7.0) with the Apache version used. Bumped to latest.

# How

We just use the library to declare the proxy host in a `HttpHost` object which can be used by clients to set up their proxy. Bumped version to 4.5.13
