### PR TITLE
Update guava and make apache use 443

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Our Java SDK is distributed via [maven](https://search.maven.org/artifact/com.ev
 
 ### Gradle
 ```sh
-implementation 'com.evervault:lib:2.0.8'
+implementation 'com.evervault:lib:2.1.0'
 ```
 
 ### Maven
@@ -38,7 +38,7 @@ implementation 'com.evervault:lib:2.0.8'
 <dependency>
   <groupId>com.evervault</groupId>
   <artifactId>lib</artifactId>
-  <version>2.0.8</version>
+  <version>2.1.0</version>
 </dependency>
 ```
 
@@ -124,7 +124,7 @@ If you use a different http client to the clients above, you can setup relay int
 | Setting   | Value                                                                   |
 |-----------|-------------------------------------------------------------------------|
 | host      | strict.relay.evervault.com                                              |
-| port      | 8443                                                                    |
+| port      | 443                                                                     |
 | user      | Your Evervault Team's UUID (Can be found in the Evervault Dashboard)    |
 | password  | Your Evervault Team's API_KEY (Can be found in the Evervault Dashboard) |
 
@@ -218,3 +218,9 @@ void encryptAndRun() throws EvervaultException {
 ### 2.0.8
 
 * Bump Apache version to 4.5.13 to handle `CVE-2020-13956`
+
+### 2.1.0
+
+* Make Apache Clients use port 443 for Evervault Proxy.
+
+* Update Guava Version to latest to resolve `CVE-2018-10237`

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group 'com.evervault'
-version '2.0.8'
+version '2.1.0'
 
 repositories {
     mavenCentral()
@@ -35,7 +35,7 @@ dependencies {
     testImplementation "org.mockito:mockito-core:3.+"
 
     implementation 'com.google.code.gson:gson:2.8.9'
-    implementation 'com.google.guava:guava:11.0.2'
+    implementation 'com.google.guava:guava:31.1-android'
     implementation group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: '1.70'
     implementation group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.13'
 

--- a/lib/src/main/java/com/evervault/services/EvervaultService.java
+++ b/lib/src/main/java/com/evervault/services/EvervaultService.java
@@ -28,6 +28,7 @@ public abstract class EvervaultService {
 
     protected final static int NEW_KEY_TIMESTAMP = 15;
     protected final static String RELAY_PORT = "8443";
+    protected final static String APACHE_RELAY_PORT = "443";
     protected final int getCageHash = "getCagePublicKeyFromEndpoint".hashCode();
     protected final int runCageHash = "runCage".hashCode();
     protected Instant currentSharedKeyTimestamp;
@@ -156,11 +157,14 @@ public abstract class EvervaultService {
         System.setProperty("http.nonProxyHosts", ignoreDomains);
     }
 
+    //Used for Apache Http Clients
     protected void setupCredentialsProvider(String apiKey) {
         this.credentialsProvider = ProxyCredentialsProvider
-                .getEvervaultCredentialsProvider(getEvervaultRelayHost(), teamUuid, apiKey);
+                .getEvervaultCredentialsProvider(getEvervaultRelayHost(), Integer.valueOf(APACHE_RELAY_PORT), teamUuid, apiKey);
     }
 
+    //Returns a CredentialsProvider to authenticate an
+    // Apache HttpClient with the Evervault Proxy.
     public CredentialsProvider getEvervaultProxyCredentials() {
         return this.credentialsProvider;
     }

--- a/lib/src/main/java/com/evervault/services/EvervaultService.java
+++ b/lib/src/main/java/com/evervault/services/EvervaultService.java
@@ -151,8 +151,6 @@ public abstract class EvervaultService {
         System.setProperty("https.proxyPassword", password);
         System.setProperty("https.nonProxyHosts", ignoreDomains);
         
-        System.setProperty("http.proxyHost", proxyHost);
-        System.setProperty("http.proxyPort", proxyPort);
         System.setProperty("http.proxyUser", user);
         System.setProperty("http.proxyPassword", password);
         System.setProperty("http.nonProxyHosts", ignoreDomains);
@@ -160,7 +158,7 @@ public abstract class EvervaultService {
 
     protected void setupCredentialsProvider(String apiKey) {
         this.credentialsProvider = ProxyCredentialsProvider
-                .getEvervaultCredentialsProvider(getEvervaultRelayHost(), Integer.valueOf(RELAY_PORT), teamUuid, apiKey);
+                .getEvervaultCredentialsProvider(getEvervaultRelayHost(), teamUuid, apiKey);
     }
 
     public CredentialsProvider getEvervaultProxyCredentials() {

--- a/lib/src/main/java/com/evervault/utils/ProxyCredentialsProvider.java
+++ b/lib/src/main/java/com/evervault/utils/ProxyCredentialsProvider.java
@@ -9,8 +9,8 @@ import java.nio.charset.StandardCharsets;
 
 public class ProxyCredentialsProvider {
 
-    public static CredentialsProvider getEvervaultCredentialsProvider(String proxyHost, Integer proxyPort, String teamUuid, String teamApiKey) {
-        AuthScope authScope= new AuthScope(AuthScope.ANY_HOST, AuthScope.ANY_PORT);
+    public static CredentialsProvider getEvervaultCredentialsProvider(String proxyHost, String teamUuid, String teamApiKey) {
+        AuthScope authScope= new AuthScope(proxyHost, AuthScope.ANY_PORT);
         UsernamePasswordCredentials credentials = new UsernamePasswordCredentials(teamUuid, teamApiKey);
 
         CredentialsProvider credentialsProvider = new BasicCredentialsProvider();

--- a/lib/src/main/java/com/evervault/utils/ProxyCredentialsProvider.java
+++ b/lib/src/main/java/com/evervault/utils/ProxyCredentialsProvider.java
@@ -10,7 +10,7 @@ import java.nio.charset.StandardCharsets;
 public class ProxyCredentialsProvider {
 
     public static CredentialsProvider getEvervaultCredentialsProvider(String proxyHost, Integer proxyPort, String teamUuid, String teamApiKey) {
-        AuthScope authScope= new AuthScope(proxyHost, proxyPort);
+        AuthScope authScope= new AuthScope(AuthScope.ANY_HOST, AuthScope.ANY_PORT);
         UsernamePasswordCredentials credentials = new UsernamePasswordCredentials(teamUuid, teamApiKey);
 
         CredentialsProvider credentialsProvider = new BasicCredentialsProvider();

--- a/lib/src/main/java/com/evervault/utils/ProxyCredentialsProvider.java
+++ b/lib/src/main/java/com/evervault/utils/ProxyCredentialsProvider.java
@@ -9,8 +9,8 @@ import java.nio.charset.StandardCharsets;
 
 public class ProxyCredentialsProvider {
 
-    public static CredentialsProvider getEvervaultCredentialsProvider(String proxyHost, String teamUuid, String teamApiKey) {
-        AuthScope authScope= new AuthScope(proxyHost, AuthScope.ANY_PORT);
+    public static CredentialsProvider getEvervaultCredentialsProvider(String proxyHost, Integer proxyPort, String teamUuid, String teamApiKey) {
+        AuthScope authScope= new AuthScope(proxyHost, proxyPort);
         UsernamePasswordCredentials credentials = new UsernamePasswordCredentials(teamUuid, teamApiKey);
 
         CredentialsProvider credentialsProvider = new BasicCredentialsProvider();

--- a/lib/src/main/java/com/evervault/utils/ProxySystemSettings.java
+++ b/lib/src/main/java/com/evervault/utils/ProxySystemSettings.java
@@ -17,5 +17,6 @@ public class ProxySystemSettings {
         return strictHost;
     };
 
-    public static HttpHost PROXY_HOST = new HttpHost(getStrictHost(), 8443);
+    //Apache Client supports HTTPS proxy so go through 443
+    public static HttpHost PROXY_HOST = new HttpHost(getStrictHost(), 443, "https");
 }


### PR DESCRIPTION
# Why
Guava version had a CVE
The Apache Http Client supports sending to evervault proxy over 443 so setting the host port to that.

# How
Updated guava version.
Changed host for ProxyHost that is used to setup the proxy for apache.
