### PR TITLE
Update readme and add RoutePlanner for Apache Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The Evervault Java SDK exposes a constructor and two functions:
 
 ### Relay Interception
 
-The Evervault Java SDK can automatically route all outbound HTTPS requests through Relay for decryption. This can be done by setting up a proxy to Evervault on your HTTP client.
+The Evervault Java SDK can be used to route all outbound HTTPS requests through Relay for decryption. This can be done by setting up a proxy to Evervault on your HTTP client.
 
 To disable this behaviour, set `intercept` to `false` in the initialization options. For the most common Java HTTP Clients, here is how intercept can be set up:
 
@@ -83,43 +83,11 @@ CloseableHttpClient httpClient = HttpClientBuilder
     .build();
 ```
 
-#### Java 11 Client
-
-When using the new Java 11 client, you will have to: 
-
-* Add a system property before the SDK is initiased to enable BASIC auth with the proxy.
-* Update HTTP Client to use the default Authenticator (The default is set by the SDK).
-
-```java
-
-import com.evervault.Evervault;
-import com.evervault.utils.ProxySystemSettings;
-
-System.setProperty(ProxySystemSettings.PROXY_DISABLED_SCHEMES_KEY, ProxySystemSettings.PROXY_DISABLED_SCHEMES_VALUE);
-var evervault = new Evervault(apiKey);
-
-HttpClient httpClient = HttpClient.newBuilder()
-  .authenticator(Authenicator.getDefault())
-  ...
-  .build();
-```
-
-#### HTTPUrlConnection API
-
-When using the original HTTPUrlConnection API, you can use intercept out of the box. When you initialize the evervault Java SDK with intercept enabled (enabled by default). It sets the JVM properties for sending a request through a proxy.
-
-```java
-// Note This is done automatically when you setup the Evervault SDK
-
-System.setProperty("http.proxyHost", proxyHost);
-System.setProperty("http.proxyPort", proxyPort);
-System.setProperty("https.proxyHost", proxyHost);
-System.setProperty("https.proxyPort", proxyPort);
-```
+*Note: We currently only support CONNECT-over-TLS in order to avoid transmitting credentials in plaintext. The Apache Http Client does support this. The core Java Http Clients do NOT currently support this.*
 
 ### Manual Proxy
 
-If you use a different http client to the clients above, you can setup relay interception by setting the http client to proxy requests through relay with these details:
+If you use a different http client to the Apache HTTPClient above, and it supports `CONNECT-over-TLS`, you can set up relay interception by setting the http client to proxy requests through relay with these details:
 
 | Setting   | Value                                                                   |
 |-----------|-------------------------------------------------------------------------|
@@ -132,7 +100,7 @@ If you use a different http client to the clients above, you can setup relay int
 
 **encrypt** will encrypt your data and return an object which is a String in case you passed a literal type like `bool`, `string`, `int`, `float`, `char`, `byte`. 
 
-In case you pass a map<literal, literal> then the key will be preserved and the value will be an encryped string. If value is another map for example, it will follow the sample principle recursively.
+In case you pass a map<literal, literal> then the key will be preserved and the value will be an encrypted string. If value is another map for example, it will follow the sample principle recursively.
 
 In case you pass a vector with literals the return will be vector with encrypted strings. 
 

--- a/README.md
+++ b/README.md
@@ -119,11 +119,11 @@ var Evervault = new Evervault("<API_KEY>")
 ```
 
 | Parameter        | Type                         | Description                                                                                                                          |
-| ---------------- | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| ---------------- | ---------------------------- |--------------------------------------------------------------------------------------------------------------------------------------|
 | `apiKey`         | `String`                     | The API key of your Evervault Team                                                                                                   |
 | `curve`          | `Evervault.EcdhCurve`        | The elliptic curve used for cryptographic operations. See [Elliptic Curve Support](/reference/elliptic-curve-support) to learn more. |
 | `intercept`      | `Boolean`                    | Route outbound requests through Evervault to automatically decrypt encrypted fields.                                                 |
-| `ignoreDomains`  | `String[]`                   | An array of hostnames which will not be routed through Evervault for encryption. eg [ "api.example.com", "support.example.com" ]        |
+| `ignoreDomains`  | `String[]`                   | An array of hostnames which will not be routed through Evervault for decryption. eg [ "api.example.com", "support.example.com" ]     |
 
 
 ### Example

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Our Java SDK is distributed via [maven](https://search.maven.org/artifact/com.ev
 
 ### Gradle
 ```sh
-implementation 'com.evervault:lib:2.1.0'
+implementation 'com.evervault:lib:2.1.1'
 ```
 
 ### Maven
@@ -38,7 +38,7 @@ implementation 'com.evervault:lib:2.1.0'
 <dependency>
   <groupId>com.evervault</groupId>
   <artifactId>lib</artifactId>
-  <version>2.1.0</version>
+  <version>2.1.1</version>
 </dependency>
 ```
 
@@ -66,7 +66,8 @@ sudo keytool -import -alias evervault-ca -file evervault-ca.cert -keystore <path
 
 #### Apache Closeable HTTP Client
 
-The Apache Closeable HTTP Client requires the proxy and credentials to be explicitly set. When initialising your http client, you will need to get the CredentialsProvider from the Evervault SDK and the host from the Evervault ProxySystemSettings class.
+The Apache Closeable HTTP Client requires the proxy and credentials to be explicitly set. When initialising your http client, you will need to get the CredentialsProvider from the Evervault SDK and the host from the Evervault ProxySystemSettings class. 
+If you set ignoreDomains when initialising the SDK, you will need to add the Evervault HttpRoutePlanner to the builder.
 
 ```java
 // Import ProxySettings for setting proxy host
@@ -80,6 +81,7 @@ CloseableHttpClient httpClient = HttpClientBuilder
     .create()
     .setProxy(ProxySystemSettings.PROXY_HOST)
     .setDefaultCredentialsProvider(evervault.getEvervaultProxyCredentials())
+    .setRoutePlanner(evervault.getEvervaultHttpRoutePlanner())  //This route planner has the ignoreDomains array loaded into it.        
     .build();
 ```
 
@@ -144,6 +146,7 @@ void encryptAndRun() throws EvervaultException {
 
     var cageResult = evervault.run(cageName, Bar.createFooStructure(evervault), false, null);
 }
+
 ```
 
 ### Changelog
@@ -192,3 +195,9 @@ void encryptAndRun() throws EvervaultException {
 * Make Apache Clients use port 443 for Evervault Proxy.
 
 * Update Guava Version to latest to resolve `CVE-2018-10237`
+
+### 2.1.1
+
+* Remove Core Java Clients. 
+
+* Add Apache Route Planner for ignore domains.

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group 'com.evervault'
-version '2.1.0'
+version '2.1.1'
 
 repositories {
     mavenCentral()

--- a/lib/src/integrationTests/java/com/evervault/WhenUsingApiAgainstRealEnvironmentTests.java
+++ b/lib/src/integrationTests/java/com/evervault/WhenUsingApiAgainstRealEnvironmentTests.java
@@ -101,7 +101,6 @@ public class WhenUsingApiAgainstRealEnvironmentTests {
     @Test
     void encryptSomeDataCorrectly() throws EvervaultException {
         final String someDataToEncrypt = "Foo";
-        System.setProperty(ProxySystemSettings.PROXY_DISABLED_SCHEMES_KEY, ProxySystemSettings.PROXY_DISABLED_SCHEMES_VALUE);
         var evervault = new Evervault(getEnvironmentApiKey());
 
         var result = (String) evervault.encrypt(someDataToEncrypt);
@@ -128,7 +127,6 @@ public class WhenUsingApiAgainstRealEnvironmentTests {
 
     @Test
     void encryptAndRun() throws EvervaultException {
-        System.setProperty(ProxySystemSettings.PROXY_DISABLED_SCHEMES_KEY, ProxySystemSettings.PROXY_DISABLED_SCHEMES_VALUE);
         var evervault = new Evervault(getEnvironmentApiKey());
         var data = Bar.createFooStructure(evervault);
         var cageResult = evervault.run(cageName, data, false, null);
@@ -138,7 +136,6 @@ public class WhenUsingApiAgainstRealEnvironmentTests {
 
     @Test
     void encryptAndRunR1Curve() throws EvervaultException {
-        System.setProperty(ProxySystemSettings.PROXY_DISABLED_SCHEMES_KEY, ProxySystemSettings.PROXY_DISABLED_SCHEMES_VALUE);
         var evervault = new Evervault(getEnvironmentApiKey(), EcdhCurve.SECP256R1);
         var data = Bar.createFooStructure(evervault);
         var cageResult = evervault.run(cageName, data, false, null);
@@ -161,7 +158,6 @@ public class WhenUsingApiAgainstRealEnvironmentTests {
 
     @Test
     void decryptDataWorksAsExpected() throws HttpFailureException, NotPossibleToHandleDataTypeException, InvalidAlgorithmParameterException, MaxRetryReachedException, IOException, NoSuchAlgorithmException, InvalidKeySpecException, InvalidKeyException, NoSuchProviderException, InterruptedException, InvalidCipherTextException, NotImplementedException, EvervaultException {
-        System.setProperty(ProxySystemSettings.PROXY_DISABLED_SCHEMES_KEY, ProxySystemSettings.PROXY_DISABLED_SCHEMES_VALUE);
         var evervault = new OwnEvervault(getEnvironmentApiKey());
 
         var bar = Bar.createFooStructure(evervault);
@@ -193,7 +189,6 @@ public class WhenUsingApiAgainstRealEnvironmentTests {
     @Test
     void interceptWorksThroughApacheHttpLibrary() throws HttpFailureException, NotPossibleToHandleDataTypeException, InvalidAlgorithmParameterException, MaxRetryReachedException, IOException, NoSuchAlgorithmException, InvalidKeySpecException, InvalidKeyException, NoSuchProviderException, InterruptedException, InvalidCipherTextException, NotImplementedException, EvervaultException, KeyManagementException {
 
-        System.setProperty(ProxySystemSettings.PROXY_DISABLED_SCHEMES_KEY, ProxySystemSettings.PROXY_DISABLED_SCHEMES_VALUE);
         var evervault = new Evervault(getEnvironmentApiKey(), EcdhCurve.SECP256R1);
 
         var encryptedString = evervault.encrypt("Secret info");
@@ -226,5 +221,50 @@ public class WhenUsingApiAgainstRealEnvironmentTests {
         httpClient.close();
         Header[] headers = response.getHeaders("x-evervault-ctx");
         assert headers.length > 0;
+    }
+
+    @Test
+    void interceptWorksThroughApacheHttpLibraryWithIgnoreDomains() throws HttpFailureException, NotPossibleToHandleDataTypeException, InvalidAlgorithmParameterException, MaxRetryReachedException, IOException, NoSuchAlgorithmException, InvalidKeySpecException, InvalidKeyException, NoSuchProviderException, InterruptedException, InvalidCipherTextException, NotImplementedException, EvervaultException, KeyManagementException {
+
+        String[] ignoreDomains = {"enssc1aqsjv0g.x.pipedream.net"};
+        var evervault = new Evervault(getEnvironmentApiKey(), EcdhCurve.SECP256R1, ignoreDomains);
+
+        var encryptedString = evervault.encrypt("Secret info");
+
+        RequestConfig config = RequestConfig.custom()
+                .setConnectTimeout(60 * 1000)
+                .setConnectionRequestTimeout(60 * 1000)
+                .setSocketTimeout(60 * 1000).build();
+
+        CloseableHttpClient httpClient = HttpClientBuilder
+                .create()
+                .setSSLContext(getSSLContextTrustAny())
+                .setDefaultRequestConfig(config)
+                .setProxy(ProxySystemSettings.PROXY_HOST)
+                .setRoutePlanner(evervault.getEvervaultHttpRoutePlanner())
+                .setDefaultCredentialsProvider(evervault.getEvervaultProxyCredentials())
+                .build();
+
+        String uri = "https://enssc1aqsjv0g.x.pipedream.net/apache-client-ignoring";
+        String uri2 = "https://httpbin.org/post";
+        String msg = getPayloadWithEncryptedString(encryptedString);
+
+        org.apache.http.client.methods.HttpPost httpPost = new HttpPost(uri);
+        httpPost.setEntity(new StringEntity(msg));
+        CloseableHttpResponse response = httpClient.execute(httpPost);
+
+        System.out.println(response);
+        Header[] headers = response.getHeaders("x-evervault-ctx");
+        assert headers.length == 0;
+
+        org.apache.http.client.methods.HttpPost httpPost2 = new HttpPost(uri2);
+        httpPost2.setEntity(new StringEntity(msg));
+        CloseableHttpResponse response2 = httpClient.execute(httpPost2);
+
+        System.out.println(response2);
+        Header[] headers2 = response2.getHeaders("x-evervault-ctx");
+        assert headers2.length > 0;
+
+        httpClient.close();
     }
 }

--- a/lib/src/integrationTests/java/com/evervault/WhenUsingApiAgainstRealEnvironmentTests.java
+++ b/lib/src/integrationTests/java/com/evervault/WhenUsingApiAgainstRealEnvironmentTests.java
@@ -191,34 +191,6 @@ public class WhenUsingApiAgainstRealEnvironmentTests {
     }
 
     @Test
-    void interceptWorksThroughJava11HttpLibrary() throws HttpFailureException, NotPossibleToHandleDataTypeException, InvalidAlgorithmParameterException, MaxRetryReachedException, IOException, NoSuchAlgorithmException, InvalidKeySpecException, InvalidKeyException, NoSuchProviderException, InterruptedException, InvalidCipherTextException, NotImplementedException, EvervaultException, KeyManagementException {
-
-        System.setProperty(ProxySystemSettings.PROXY_DISABLED_SCHEMES_KEY, ProxySystemSettings.PROXY_DISABLED_SCHEMES_VALUE);
-        var evervault = new Evervault(getEnvironmentApiKey(), EcdhCurve.SECP256R1);
-
-        var encryptedString = evervault.encrypt("Secret info");
-
-        HttpClient httpClient = HttpClient.newBuilder()
-                .sslContext(getSSLContextTrustAny())
-                .authenticator(Authenticator.getDefault())
-                .build();
-
-        String uri = "https://enssc1aqsjv0g.x.pipedream.net/java-11";
-        String msg = getPayloadWithEncryptedString(encryptedString);
-
-        HttpRequest request = HttpRequest.newBuilder()
-                .uri(URI.create(uri))
-                .POST(HttpRequest.BodyPublishers.ofString(msg))
-                .build();
-
-        HttpResponse<?> response = httpClient.send(request, HttpResponse.BodyHandlers.discarding());
-
-        System.out.println(response.headers());
-        assert response.headers().map().get("x-evervault-ctx") != null;
-        assert response.statusCode() == 200;
-    }
-
-    @Test
     void interceptWorksThroughApacheHttpLibrary() throws HttpFailureException, NotPossibleToHandleDataTypeException, InvalidAlgorithmParameterException, MaxRetryReachedException, IOException, NoSuchAlgorithmException, InvalidKeySpecException, InvalidKeyException, NoSuchProviderException, InterruptedException, InvalidCipherTextException, NotImplementedException, EvervaultException, KeyManagementException {
 
         System.setProperty(ProxySystemSettings.PROXY_DISABLED_SCHEMES_KEY, ProxySystemSettings.PROXY_DISABLED_SCHEMES_VALUE);

--- a/lib/src/integrationTests/java/com/evervault/WhenUsingApiAgainstRealEnvironmentTests.java
+++ b/lib/src/integrationTests/java/com/evervault/WhenUsingApiAgainstRealEnvironmentTests.java
@@ -253,7 +253,6 @@ public class WhenUsingApiAgainstRealEnvironmentTests {
         httpPost.setEntity(new StringEntity(msg));
         CloseableHttpResponse response = httpClient.execute(httpPost);
 
-        System.out.println(response);
         Header[] headers = response.getHeaders("x-evervault-ctx");
         assert headers.length == 0;
 
@@ -261,7 +260,6 @@ public class WhenUsingApiAgainstRealEnvironmentTests {
         httpPost2.setEntity(new StringEntity(msg));
         CloseableHttpResponse response2 = httpClient.execute(httpPost2);
 
-        System.out.println(response2);
         Header[] headers2 = response2.getHeaders("x-evervault-ctx");
         assert headers2.length > 0;
 

--- a/lib/src/main/java/com/evervault/utils/ProxyRoutePlanner.java
+++ b/lib/src/main/java/com/evervault/utils/ProxyRoutePlanner.java
@@ -1,0 +1,39 @@
+package com.evervault.utils;
+
+import org.apache.http.HttpException;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpRequest;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.conn.routing.HttpRoute;
+import org.apache.http.conn.routing.HttpRoutePlanner;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.conn.DefaultProxyRoutePlanner;
+import org.apache.http.protocol.HttpContext;
+
+import java.util.Arrays;
+
+public class ProxyRoutePlanner {
+
+    public static HttpRoutePlanner getEvervaultRoutePlanner(String[] ignoreDomains) {
+
+        HttpRoutePlanner routePlanner = new DefaultProxyRoutePlanner(ProxySystemSettings.PROXY_HOST) {
+            public HttpRoute determineRoute(
+                    final HttpHost host,
+                    final HttpRequest request,
+                    final HttpContext context) throws HttpException {
+                String hostname = host.getHostName();
+
+                boolean ignoredDomain = Arrays.stream(ignoreDomains).anyMatch(hostname::equals);
+                if (ignoredDomain) {
+                    // Return direct route
+                    return new HttpRoute(host);
+                }
+                return super.determineRoute(host, request, context);
+            }
+        };
+
+        return routePlanner;
+    }
+}


### PR DESCRIPTION
# Why

Core Java Http Clients don't support CONNECT-over-TLS so removing references in readme.
Also added `HTTPRoutePlanner` for making using ignoreDomains easier with the apache client.

# How
Updated readme and added class ProxyRoutePlanner
