### PR TITLE
Add support of gradle-nexus.publish-plugin to automate maven/nexus deployment

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -56,4 +56,4 @@ jobs:
       - name: install dependencies
         run: sudo ./install_dependencies.bash
       - name: publish
-        run: ./gradlew publishMavenjavaPublicationToSonatypeRepository
+        run: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,20 @@
+plugins {
+    id 'io.github.gradle-nexus.publish-plugin' version '1.1.0'
+}
+
+def getRepositoryUsername() {
+    return hasProperty("ossrhUsername") ? ossrhUsername : ""
+}
+
+def getRepositoryPassword() {
+    return hasProperty("ossrhPassword") ? ossrhPassword : ""
+}
+
+nexusPublishing {
+    repositories {
+        sonatype {
+            username = getRepositoryUsername()
+            password = getRepositoryPassword()
+        }
+    }
+}

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -13,14 +13,6 @@ repositories {
     mavenLocal()
 }
 
-def getRepositoryUsername() {
-    return hasProperty("ossrhUsername") ? ossrhUsername : ""
-}
-
-def getRepositoryPassword() {
-    return hasProperty("ossrhPassword") ? ossrhPassword : ""
-}
-
 def getKeyFile() {
     return hasProperty("signingKey") ? signingKey : ""
 }
@@ -91,18 +83,6 @@ publishing {
                     name = 'Evervault'
                     url = 'https://www.evervault.com/'
                 }
-            }
-        }
-    }
-    repositories {
-        maven {
-            name = 'sonatype'
-            def releasesRepoUrl = 'https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/'
-            def snapshotsRepoUrl = 'https://s01.oss.sonatype.org/content/repositories/snapshots/'
-            url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
-            credentials {
-                username getRepositoryUsername()
-                password getRepositoryPassword()
             }
         }
     }


### PR DESCRIPTION
# Why
We currently manually release new versions of the SDK to Maven using the nexus dashboard. This process is [relatively tedious](https://central.sonatype.org/publish/release/#locate-and-examine-your-staging-repository) (you need to login to Nexus, close the staging repo and publish it). This step can be automated in order to simplify the release process.

# How
Implement the new Nexus Publish plugin and rely on `publishToSonatype closeAndReleaseSonatypeStagingRepository` to publish to the Nexus repository, close the staging repository and release it.