### PR TITLE
feat(decrypt function)!: Add decrypt function support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ build
 
 # bin dir
 lib/bin
+
+# Ignore VSCode directory
+.vscode

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ The Evervault Java SDK exposes a constructor and two functions:
 * `evervault.encrypt()`
 * `evervault.run()`
 * `evervault.createRunToken()`
+* `evervault.decrypt()`
 
 ### Relay Interception
 
@@ -103,7 +104,13 @@ If you use a different http client to the Apache HTTPClient above, and it suppor
 
 In case you pass a map<literal, literal> then the key will be preserved and the value will be an encrypted string. If value is another map for example, it will follow the sample principle recursively.
 
-In case you pass a vector with literals the return will be vector with encrypted strings. 
+In case you pass a vector with literals the return will be vector with encrypted strings.
+
+### decrypt
+
+**decrypt** will take your encrypted data and decrypt it. It will also deserialise the data into an object of a specified type.
+
+The decrypt function requires the type of `data` is of `Map<String, Object>`.
 
 ### run
 
@@ -115,15 +122,16 @@ createRunToken will create a single use, time bound token for invoking a cage.
 
 ### constructor
 
-Evervault constructor expects your api key which you can retrieve from evervault website. There are also optional parameters.
+Evervault constructor expects your api key which you can retrieve from evervault dashboard and your App ID which can also be retrieved from the dashboard. There are also optional parameters.
 
 ```java
-var Evervault = new Evervault("<API_KEY>")
+var Evervault = new Evervault("<API_KEY>", "<APP_ID>")
 ```
 
 | Parameter              | Type                  | Description                                                                                                                                                      |
 |------------------------|-----------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `apiKey`               | `String`              | The API key of your Evervault Team                                                                                                                               |
+| `apiKey`               | `String`              | The API key of your Evervault App                                                                                                                                |
+| `appUuid`              | `String`              | The App ID of your Evervault App
 | `curve`                | `Evervault.EcdhCurve` | The elliptic curve used for cryptographic operations. See [Elliptic Curve Support](/reference/elliptic-curve-support) to learn more.                             |
 | `decryptionDomains`    | `String[]`            | An array of hostnames which will be routed through Evervault for decryption, supports wildcards. eg [ "api.example.com", "support.example.com, "*.example.com" ] |
 | `enableOutboundRelay`  | `boolean`             | Enables Outbound Relay by syncing your configuration from the Evervault App. This feature is currently in beta.                                                  |
@@ -145,9 +153,33 @@ private static class Bar {
 }
 
 void encryptAndRun() throws EvervaultException {
-    var evervault = new Evervault(getEnvironmentApiKey());
+    var evervault = new Evervault(getEnvironmentApiKey(), getEnvironmentAppUuid());
 
     var cageResult = evervault.run(cageName, Bar.createFooStructure(evervault), false, null);
+}
+
+```
+
+### Decrypt Examaple
+```java
+private static class Bar {
+    public String name;
+}
+
+void encryptAndDecrypt() throws EvervaultException {
+    var evervault = new Evervault(getEnvironmentApiKey(), getEnvironmentAppUuid());
+
+    // Encrypt some data
+    var encryptedName = (String) evervault.encrypt("foo");
+
+    // Decrypt the previously encrypted data
+    var dataToDecrypt = new HashMap<String, String>();
+    dataToDecrypt.put("name", encryptedName);
+
+    // Decrypts and deserialises the encrypted data into a `Bar` instance
+    Bar decryptedData = evervault.decrypt(dataToDecrypt, Bar.class);
+
+    System.out.println(decryptedData.name); // Prints `foo`
 }
 
 ```

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ void encryptAndRun() throws EvervaultException {
 
 ```
 
-### Decrypt Examaple
+### Decrypt Example
 ```java
 private static class Bar {
     public String name;
@@ -259,3 +259,7 @@ void encryptAndDecrypt() throws EvervaultException {
 ### 3.3.2
 
 * Allow unsigned payloads when creating run tokens
+
+### 4.0.0
+
+* Introduce decrypt method

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group 'com.evervault'
-version '3.3.2'
+version '4.0.0'
 
 repositories {
     mavenCentral()

--- a/lib/src/integrationTests/java/com/evervault/WhenUsingApiAgainstRealEnvironmentTests.java
+++ b/lib/src/integrationTests/java/com/evervault/WhenUsingApiAgainstRealEnvironmentTests.java
@@ -77,7 +77,7 @@ public class WhenUsingApiAgainstRealEnvironmentTests {
     };
 
     public String getEnvironmentAppUuid() {
-        return System.getenv(ENV_APP_UUID);
+        return "app_12345678987";
     }
 
     public String getEnvironmentApiKey() {

--- a/lib/src/integrationTests/java/com/evervault/WhenUsingApiAgainstRealEnvironmentTests.java
+++ b/lib/src/integrationTests/java/com/evervault/WhenUsingApiAgainstRealEnvironmentTests.java
@@ -95,13 +95,13 @@ public class WhenUsingApiAgainstRealEnvironmentTests {
 
     @Test
     void doesThrowWhenInvalidKey() {
-        assertThrows(EvervaultException.class, () -> new Evervault("foo"));
+        assertThrows(EvervaultException.class, () -> new Evervault("foo", "bar"));
     }
 
     @Test
     void encryptSomeDataCorrectly() throws EvervaultException {
         final String someDataToEncrypt = "Foo";
-        var evervault = new Evervault(getEnvironmentApiKey());
+        var evervault = new Evervault(getEnvironmentApiKey(), "bar");
 
         var result = (String) evervault.encrypt(someDataToEncrypt);
 
@@ -127,7 +127,7 @@ public class WhenUsingApiAgainstRealEnvironmentTests {
 
     @Test
     void encryptAndRun() throws EvervaultException {
-        var evervault = new Evervault(getEnvironmentApiKey());
+        var evervault = new Evervault(getEnvironmentApiKey(), "bar");
         var data = Bar.createFooStructure(evervault);
         var cageResult = evervault.run(cageName, data, false, null);
 
@@ -136,7 +136,7 @@ public class WhenUsingApiAgainstRealEnvironmentTests {
 
     @Test
     void encryptAndRunR1Curve() throws EvervaultException {
-        var evervault = new Evervault(getEnvironmentApiKey(), EcdhCurve.SECP256R1);
+        var evervault = new Evervault(getEnvironmentApiKey(), "bar", EcdhCurve.SECP256R1);
         var data = Bar.createFooStructure(evervault);
         var cageResult = evervault.run(cageName, data, false, null);
 
@@ -145,7 +145,7 @@ public class WhenUsingApiAgainstRealEnvironmentTests {
 
     @Test
     void createRunToken() throws EvervaultException {
-        var evervault = new Evervault(getEnvironmentApiKey());
+        var evervault = new Evervault(getEnvironmentApiKey(), "bar");
         var data = Bar.createFooStructure(evervault);
         var runTokenResult = evervault.createRunToken(cageName, data);
         
@@ -153,8 +153,8 @@ public class WhenUsingApiAgainstRealEnvironmentTests {
     }
 
     private static class OwnEvervault extends Evervault {
-        public OwnEvervault(String apiKey) throws EvervaultException {
-            super(apiKey);
+        public OwnEvervault(String apiKey, String appUuid) throws EvervaultException {
+            super(apiKey, appUuid);
         }
 
         public byte[] getSharedKey() {
@@ -167,7 +167,7 @@ public class WhenUsingApiAgainstRealEnvironmentTests {
 
     @Test
     void decryptDataWorksAsExpected() throws HttpFailureException, NotPossibleToHandleDataTypeException, InvalidAlgorithmParameterException, MaxRetryReachedException, IOException, NoSuchAlgorithmException, InvalidKeySpecException, InvalidKeyException, NoSuchProviderException, InterruptedException, InvalidCipherTextException, NotImplementedException, EvervaultException {
-        var evervault = new OwnEvervault(getEnvironmentApiKey());
+        var evervault = new OwnEvervault(getEnvironmentApiKey(), "bar");
 
         var bar = Bar.createFooStructure(evervault);
 
@@ -198,7 +198,7 @@ public class WhenUsingApiAgainstRealEnvironmentTests {
     @Test
     void interceptWorksThroughApacheHttpLibrary() throws HttpFailureException, NotPossibleToHandleDataTypeException, InvalidAlgorithmParameterException, MaxRetryReachedException, IOException, NoSuchAlgorithmException, InvalidKeySpecException, InvalidKeyException, NoSuchProviderException, InterruptedException, InvalidCipherTextException, NotImplementedException, EvervaultException, KeyManagementException {
 
-        var evervault = new Evervault(getEnvironmentApiKey(), EcdhCurve.SECP256R1);
+        var evervault = new Evervault(getEnvironmentApiKey(), "bar", EcdhCurve.SECP256R1);
 
         var encryptedString = evervault.encrypt("Secret info");
 
@@ -234,7 +234,7 @@ public class WhenUsingApiAgainstRealEnvironmentTests {
 
     @Test
     void interceptWithDecryptionDomainsWorksThroughApacheHttpLibrary() throws HttpFailureException, NotPossibleToHandleDataTypeException, InvalidAlgorithmParameterException, MaxRetryReachedException, IOException, NoSuchAlgorithmException, InvalidKeySpecException, InvalidKeyException, NoSuchProviderException, InterruptedException, InvalidCipherTextException, NotImplementedException, EvervaultException, KeyManagementException {
-        var evervault = new Evervault(getEnvironmentApiKey(), new String[] {"*.pipedream.net"}, EcdhCurve.SECP256R1);
+        var evervault = new Evervault(getEnvironmentApiKey(), "bar", new String[] {"*.pipedream.net"}, EcdhCurve.SECP256R1);
 
         var encryptedString = evervault.encrypt("Secret info");
 
@@ -270,7 +270,7 @@ public class WhenUsingApiAgainstRealEnvironmentTests {
 
     @Test
     void interceptWithOutboundRelayConfigWorksThroughApacheHttpLibrary() throws HttpFailureException, NotPossibleToHandleDataTypeException, InvalidAlgorithmParameterException, MaxRetryReachedException, IOException, NoSuchAlgorithmException, InvalidKeySpecException, InvalidKeyException, NoSuchProviderException, InterruptedException, InvalidCipherTextException, NotImplementedException, EvervaultException, KeyManagementException {
-        var evervault = new Evervault(getEnvironmentApiKey(), true, EcdhCurve.SECP256R1);
+        var evervault = new Evervault(getEnvironmentApiKey(), "bar", true, EcdhCurve.SECP256R1);
 
         var encryptedString = evervault.encrypt("Secret info");
 

--- a/lib/src/integrationTests/java/com/evervault/WhenUsingApiAgainstRealEnvironmentTests.java
+++ b/lib/src/integrationTests/java/com/evervault/WhenUsingApiAgainstRealEnvironmentTests.java
@@ -100,7 +100,7 @@ public class WhenUsingApiAgainstRealEnvironmentTests {
     @Test
     void encryptSomeDataCorrectly() throws EvervaultException {
         final String someDataToEncrypt = "Foo";
-        var evervault = new Evervault(getEnvironmentApiKey(), "bar");
+        var evervault = new Evervault("app_id", getEnvironmentApiKey());
 
         var result = (String) evervault.encrypt(someDataToEncrypt);
 
@@ -126,7 +126,7 @@ public class WhenUsingApiAgainstRealEnvironmentTests {
 
     @Test
     void encryptAndRun() throws EvervaultException {
-        var evervault = new Evervault(getEnvironmentApiKey(), "bar");
+        var evervault = new Evervault( "app_id", getEnvironmentApiKey());
         var data = Bar.createFooStructure(evervault);
         var cageResult = evervault.run(cageName, data, false, null);
 
@@ -144,7 +144,7 @@ public class WhenUsingApiAgainstRealEnvironmentTests {
 
     @Test
     void createRunToken() throws EvervaultException {
-        var evervault = new Evervault(getEnvironmentApiKey(), "bar");
+        var evervault = new Evervault("app_id", getEnvironmentApiKey(),);
         var data = Bar.createFooStructure(evervault);
         var runTokenResult = evervault.createRunToken(cageName, data);
         

--- a/lib/src/integrationTests/java/com/evervault/WhenUsingApiAgainstRealEnvironmentTests.java
+++ b/lib/src/integrationTests/java/com/evervault/WhenUsingApiAgainstRealEnvironmentTests.java
@@ -144,7 +144,7 @@ public class WhenUsingApiAgainstRealEnvironmentTests {
 
     @Test
     void createRunToken() throws EvervaultException {
-        var evervault = new Evervault("app_id", getEnvironmentApiKey(),);
+        var evervault = new Evervault("app_id", getEnvironmentApiKey());
         var data = Bar.createFooStructure(evervault);
         var runTokenResult = evervault.createRunToken(cageName, data);
         

--- a/lib/src/main/java/com/evervault/Evervault.java
+++ b/lib/src/main/java/com/evervault/Evervault.java
@@ -56,31 +56,31 @@ public class Evervault extends EvervaultService {
         this.evervaultIgnoreDomains = new String[]{ getEvervaultApiHost(), getEvervaultRunHost() };
     }
 
-    public Evervault(String apiKey) throws EvervaultException {
-        this(apiKey, EcdhCurve.SECP256K1, null, false);
+    public Evervault(String apiKey, String appUuid) throws EvervaultException {
+        this(apiKey, appUuid, EcdhCurve.SECP256K1, null, false);
     }
 
-    public Evervault(String apiKey, EcdhCurve ecdhCurve) throws EvervaultException {
-        this(apiKey, ecdhCurve, null, false);
+    public Evervault(String apiKey, String appUuid, EcdhCurve ecdhCurve) throws EvervaultException {
+        this(apiKey, appUuid, ecdhCurve, null, false);
     }
 
-    public Evervault(String apiKey, String[] decryptionDomains) throws EvervaultException {
-        this(apiKey, decryptionDomains, EcdhCurve.SECP256K1);
+    public Evervault(String apiKey, String appUuid, String[] decryptionDomains) throws EvervaultException {
+        this(apiKey, appUuid, decryptionDomains, EcdhCurve.SECP256K1);
     }
 
-    public Evervault(String apiKey, String[] decryptionDomains, EcdhCurve ecdhCurve) throws EvervaultException {
-        this(apiKey, ecdhCurve, decryptionDomains, false);
+    public Evervault(String apiKey, String appUuid, String[] decryptionDomains, EcdhCurve ecdhCurve) throws EvervaultException {
+        this(apiKey, appUuid, ecdhCurve, decryptionDomains, false);
     }
 
-    public Evervault(String apiKey, Boolean enableOutboundRelay, EcdhCurve ecdhCurve) throws EvervaultException {
-        this(apiKey, ecdhCurve, null, enableOutboundRelay);
+    public Evervault(String apiKey, String appUuid, Boolean enableOutboundRelay, EcdhCurve ecdhCurve) throws EvervaultException {
+        this(apiKey, appUuid, ecdhCurve, null, enableOutboundRelay);
     }
 
-    public Evervault(String apiKey, Boolean enableOutboundRelay) throws EvervaultException {
-        this(apiKey, EcdhCurve.SECP256K1, null, enableOutboundRelay);
+    public Evervault(String apiKey, String appUuid, Boolean enableOutboundRelay) throws EvervaultException {
+        this(apiKey, appUuid, EcdhCurve.SECP256K1, null, enableOutboundRelay);
     }
 
-    private Evervault(String apiKey, EcdhCurve ecdhCurve, String[] decryptionDomains, Boolean enableOutboundRelay) throws EvervaultException {
+    private Evervault(String apiKey, String appUuid, EcdhCurve ecdhCurve, String[] decryptionDomains, Boolean enableOutboundRelay) throws EvervaultException {
         setEvervaultApiHost();
         setEvervaultRunHost();
         setEvervaultRelayUrl();
@@ -88,7 +88,7 @@ public class Evervault extends EvervaultService {
 
         this.evervaultDecryptionDomains = decryptionDomains;
 
-        var httpHandler = new HttpHandler(apiKey);
+        var httpHandler = new HttpHandler(apiKey, appUuid);
         var encryptService = EncryptionServiceFactory.build(ecdhCurve);
         var circuitBreaker = new CircuitBreaker();
         var timeService = new TimeService();
@@ -98,6 +98,7 @@ public class Evervault extends EvervaultService {
         this.setupCageExecutionProvider(httpHandler);
         this.setupRunTokenProvider(httpHandler);
         this.setupOutboundRelayConfigProvider(httpHandler);
+        this.setupDecryptProvider(httpHandler);
         this.setupRepeatableTaskScheduler(taskScheduler);
 
         this.setupKeyProviders(httpHandler, encryptService, encryptService, timeService, ecdhCurve);

--- a/lib/src/main/java/com/evervault/Evervault.java
+++ b/lib/src/main/java/com/evervault/Evervault.java
@@ -56,28 +56,20 @@ public class Evervault extends EvervaultService {
         this.evervaultIgnoreDomains = new String[]{ getEvervaultApiHost(), getEvervaultRunHost() };
     }
 
-    public Evervault(String apiKey, String appUuid) throws EvervaultException {
-        this(apiKey, appUuid, EcdhCurve.SECP256K1, null, false);
+    public Evervault(String appId, String apiKey) throws EvervaultException {
+        this(apiKey, appId, EcdhCurve.SECP256K1, null, false);
     }
 
-    public Evervault(String apiKey, String appUuid, EcdhCurve ecdhCurve) throws EvervaultException {
-        this(apiKey, appUuid, ecdhCurve, null, false);
+    public Evervault(String appId, String apiKey, EcdhCurve ecdhCurve) throws EvervaultException {
+        this(apiKey, appId, ecdhCurve, null, false);
     }
 
-    public Evervault(String apiKey, String appUuid, String[] decryptionDomains) throws EvervaultException {
-        this(apiKey, appUuid, decryptionDomains, EcdhCurve.SECP256K1);
+    public Evervault(String appId, String apiKey, Boolean enableOutboundRelay, EcdhCurve ecdhCurve) throws EvervaultException {
+        this(apiKey, appId, ecdhCurve, null, enableOutboundRelay);
     }
 
-    public Evervault(String apiKey, String appUuid, String[] decryptionDomains, EcdhCurve ecdhCurve) throws EvervaultException {
-        this(apiKey, appUuid, ecdhCurve, decryptionDomains, false);
-    }
-
-    public Evervault(String apiKey, String appUuid, Boolean enableOutboundRelay, EcdhCurve ecdhCurve) throws EvervaultException {
-        this(apiKey, appUuid, ecdhCurve, null, enableOutboundRelay);
-    }
-
-    public Evervault(String apiKey, String appUuid, Boolean enableOutboundRelay) throws EvervaultException {
-        this(apiKey, appUuid, EcdhCurve.SECP256K1, null, enableOutboundRelay);
+    public Evervault(String appId, String apiKey, Boolean enableOutboundRelay) throws EvervaultException {
+        this(apiKey, appId, EcdhCurve.SECP256K1, null, enableOutboundRelay);
     }
 
     private Evervault(String apiKey, String appUuid, EcdhCurve ecdhCurve, String[] decryptionDomains, Boolean enableOutboundRelay) throws EvervaultException {

--- a/lib/src/main/java/com/evervault/contracts/IProvideDecrypt.java
+++ b/lib/src/main/java/com/evervault/contracts/IProvideDecrypt.java
@@ -1,0 +1,9 @@
+package com.evervault.contracts;
+
+import com.evervault.exceptions.HttpFailureException;
+
+import java.io.IOException;
+
+public interface IProvideDecrypt {
+    <T> T decrypt(String url, Object data, Class<T> valueType) throws HttpFailureException, IOException, InterruptedException;
+}

--- a/lib/src/main/java/com/evervault/dataHandlers/BooleanHandler.java
+++ b/lib/src/main/java/com/evervault/dataHandlers/BooleanHandler.java
@@ -1,5 +1,6 @@
 package com.evervault.dataHandlers;
 
+import java.nio.charset.StandardCharsets;
 import java.security.PublicKey;
 
 import com.evervault.contracts.DataHeader;
@@ -31,8 +32,8 @@ public class BooleanHandler implements IDataHandler {
     @Override
     public Object encrypt(IProvideEncryptionForObject context, Object data) throws NotPossibleToHandleDataTypeException, InvalidCipherException, NotImplementedException {
         var original = (boolean) data;
-        var byteToEncrypt = original ? (byte)1 : (byte)0;
+        var formatted_data = original ? "true" : "false";
 
-        return encryptionProvider.encryptData(DataHeader.Boolean, generatedEcdhKey, new byte[] { byteToEncrypt }, sharedKey, teamPublicKey);
+        return encryptionProvider.encryptData(DataHeader.Boolean, generatedEcdhKey, formatted_data.getBytes(StandardCharsets.UTF_8), sharedKey, teamPublicKey);
     }
 }

--- a/lib/src/main/java/com/evervault/services/HttpHandler.java
+++ b/lib/src/main/java/com/evervault/services/HttpHandler.java
@@ -1,7 +1,9 @@
 package com.evervault.services;
 
+import com.evervault.utils.Base64Handler;
 import com.evervault.contracts.IProvideCageExecution;
 import com.evervault.contracts.IProvideCagePublicKeyFromHttpApi;
+import com.evervault.contracts.IProvideDecrypt;
 import com.evervault.contracts.IProvideOutboundRelayConfigFromHttpApi;
 import com.evervault.contracts.IProvideRunToken;
 import com.evervault.exceptions.HttpFailureException;
@@ -21,7 +23,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
-public class HttpHandler implements IProvideCagePublicKeyFromHttpApi, IProvideCageExecution, IProvideRunToken, IProvideOutboundRelayConfigFromHttpApi {
+public class HttpHandler implements IProvideCagePublicKeyFromHttpApi, IProvideCageExecution, IProvideRunToken, IProvideOutboundRelayConfigFromHttpApi, IProvideDecrypt {
 
     private final java.net.http.HttpClient client;
     private final static String VERSION_PREFIX = "evervault-java/";
@@ -33,14 +35,16 @@ public class HttpHandler implements IProvideCagePublicKeyFromHttpApi, IProvideCa
     private final static long TIMEOUT_SECONDS_DEFAULT = 30;
     private final static String CAGES_KEY_SUFFIX = "/cages/key";
     private final String apiKey;
+    private final String appUuid;
     private final Duration httpTimeout;
 
-    public HttpHandler(String apiKey) {
-        this(apiKey, Duration.ofSeconds(TIMEOUT_SECONDS_DEFAULT));
+    public HttpHandler(String apiKey, String appUuid) {
+        this(apiKey, appUuid, Duration.ofSeconds(TIMEOUT_SECONDS_DEFAULT));
     }
 
-    public HttpHandler(String apiKey, Duration httpTimeout) {
+    public HttpHandler(String apiKey, String appUuid, Duration httpTimeout) {
         this.apiKey = apiKey;
+        this.appUuid = appUuid;
         this.httpTimeout = httpTimeout;
         client = java.net.http.HttpClient.newHttpClient();
     }
@@ -49,10 +53,20 @@ public class HttpHandler implements IProvideCagePublicKeyFromHttpApi, IProvideCa
         return this.getCagePublicKeyFromEndpoint(url, null);
     }
 
+    private String buildAuthorizationHeaderValue() {
+        var input = appUuid + ":" + apiKey;
+        var encodedValue = Base64Handler.encodeBase64(input.getBytes());
+        StringBuilder builder = new StringBuilder();
+        builder.append("Bearer ")
+            .append(encodedValue);
+        return builder.toString();
+    }
+
     public CagePublicKey getCagePublicKeyFromEndpoint(String url, Map<String, String> headerMap) throws IOException, InterruptedException, HttpFailureException {
         var uri = URI.create(url);
         var finalAddress = uri.resolve(CAGES_KEY_SUFFIX);
 
+        var authHeaderValue = this.buildAuthorizationHeaderValue();
         var requestBuilder = HttpRequest.newBuilder()
                 .uri(finalAddress)
                 .timeout(httpTimeout)
@@ -61,6 +75,7 @@ public class HttpHandler implements IProvideCagePublicKeyFromHttpApi, IProvideCa
                 .setHeader("Accept", JSON_CONTENT_TYPE)
                 .setHeader("Content-Type", JSON_CONTENT_TYPE)
                 .setHeader("Api-Key", apiKey)
+                .setHeader("Authorization", authHeaderValue)
                 .GET();
 
         if (headerMap != null) {
@@ -88,12 +103,14 @@ public class HttpHandler implements IProvideCagePublicKeyFromHttpApi, IProvideCa
         var uri = URI.create(url);
         var finalAddress = uri.resolve("/" + cageName);
 
+        var authHeaderValue = this.buildAuthorizationHeaderValue();
         var requestBuilder = HttpRequest.newBuilder()
                 .uri(finalAddress)
                 .setHeader("Api-Key", apiKey)
                 .setHeader("User-Agent", VERSION_PREFIX + 1.0)
                 .setHeader("Accept", JSON_CONTENT_TYPE)
                 .setHeader("Content-Type", JSON_CONTENT_TYPE)
+                .setHeader("Authorization", authHeaderValue)
                 .timeout(httpTimeout)
                 .POST(BodyPublishers.ofString(serializedData));
 
@@ -117,18 +134,48 @@ public class HttpHandler implements IProvideCagePublicKeyFromHttpApi, IProvideCa
     }
 
     @Override
+    public <T> T decrypt(String url, Object data, Class<T> valueType) throws HttpFailureException, IOException, InterruptedException {
+        var serializedData = new Gson().toJson(data);
+
+        var uri = URI.create(url);
+        var finalAddress = uri.resolve("/decrypt");
+
+        var authHeaderValue = this.buildAuthorizationHeaderValue();
+        var requestBuilder = HttpRequest.newBuilder()
+            .uri(finalAddress)
+            .setHeader("Api-Key", apiKey)
+            .setHeader("User-Agent", VERSION_PREFIX + 1.0)
+            .setHeader("Accept", JSON_CONTENT_TYPE)
+            .setHeader("Content-Type", JSON_CONTENT_TYPE)
+            .setHeader("Authorization", authHeaderValue)
+            .timeout(httpTimeout)
+            .POST(BodyPublishers.ofString(serializedData));
+        var request = requestBuilder.build();
+
+        var response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+        if (response.statusCode() != OK_HTTP_STATUS_CODE){
+            throw new HttpFailureException(response.statusCode(), response.body());
+        }
+
+        return new Gson().fromJson(response.body(), valueType);
+    }
+
+    @Override
     public RunTokenResult createRunToken(String url, String cageName, Object data) throws HttpFailureException, IOException, InterruptedException {
         var serializedData = new Gson().toJson(data);
 
         var uri = URI.create(url);
         var finalAddress = uri.resolve("/v2/functions/" + cageName + "/run-token");
 
+        var authHeaderValue = this.buildAuthorizationHeaderValue();
         var requestBuilder = HttpRequest.newBuilder()
                 .uri(finalAddress)
                 .setHeader("Api-Key", apiKey)
                 .setHeader("User-Agent", VERSION_PREFIX + 1.0)
                 .setHeader("Accept", JSON_CONTENT_TYPE)
                 .setHeader("Content-Type", JSON_CONTENT_TYPE)
+                .setHeader("Authorization", authHeaderValue)
                 .timeout(httpTimeout)
                 .POST(BodyPublishers.ofString(serializedData));
 
@@ -152,12 +199,14 @@ public class HttpHandler implements IProvideCagePublicKeyFromHttpApi, IProvideCa
         var uri = URI.create(url);
         var finalAddress = uri.resolve("/v2/functions/" + cageName + "/run-token");
 
+        var authHeaderValue = this.buildAuthorizationHeaderValue();
         var requestBuilder = HttpRequest.newBuilder()
                 .uri(finalAddress)
                 .setHeader("Api-Key", apiKey)
                 .setHeader("User-Agent", VERSION_PREFIX + 1.0)
                 .setHeader("Accept", JSON_CONTENT_TYPE)
                 .setHeader("Content-Type", JSON_CONTENT_TYPE)
+                .setHeader("Authorization", authHeaderValue)
                 .timeout(httpTimeout)
                 .POST(BodyPublishers.ofString(serializedData));
 
@@ -176,12 +225,14 @@ public class HttpHandler implements IProvideCagePublicKeyFromHttpApi, IProvideCa
         var uri = URI.create(url);
         var finalAddress = uri.resolve("/v2/relay-outbound");
 
+        var authHeaderValue = this.buildAuthorizationHeaderValue();
         var requestBuilder = HttpRequest.newBuilder()
                 .uri(finalAddress)
                 .setHeader("Api-Key", apiKey)
                 .setHeader("User-Agent", VERSION_PREFIX + 1.0)
                 .setHeader("Accept", JSON_CONTENT_TYPE)
                 .setHeader("AcceptEncoding", "gzip, deflate")
+                .setHeader("Authorization", authHeaderValue)
                 .timeout(httpTimeout)
                 .GET();
 

--- a/lib/src/main/java/com/evervault/services/HttpHandler.java
+++ b/lib/src/main/java/com/evervault/services/HttpHandler.java
@@ -57,7 +57,7 @@ public class HttpHandler implements IProvideCagePublicKeyFromHttpApi, IProvideCa
         var input = appUuid + ":" + apiKey;
         var encodedValue = Base64Handler.encodeBase64(input.getBytes());
         StringBuilder builder = new StringBuilder();
-        builder.append("Bearer ")
+        builder.append("Basic ")
             .append(encodedValue);
         return builder.toString();
     }
@@ -143,7 +143,6 @@ public class HttpHandler implements IProvideCagePublicKeyFromHttpApi, IProvideCa
         var authHeaderValue = this.buildAuthorizationHeaderValue();
         var requestBuilder = HttpRequest.newBuilder()
             .uri(finalAddress)
-            .setHeader("Api-Key", apiKey)
             .setHeader("User-Agent", VERSION_PREFIX + 1.0)
             .setHeader("Accept", JSON_CONTENT_TYPE)
             .setHeader("Content-Type", JSON_CONTENT_TYPE)

--- a/lib/src/test/java/com/evervault/WhenDealingWithHttpTimeoutsTests.java
+++ b/lib/src/test/java/com/evervault/WhenDealingWithHttpTimeoutsTests.java
@@ -17,6 +17,7 @@ import static org.junit.jupiter.api.Assertions.*;
 @WireMockTest
 public class WhenDealingWithHttpTimeoutsTests {
     private static final String API_KEY = "Foo";
+    private static final String APP_UUID = "Bar";
 
     @Test
     void triggersExceptionWhenHittingPublicKeyEndpoint(WireMockRuntimeInfo wireMockRuntimeInfo) {
@@ -27,7 +28,7 @@ public class WhenDealingWithHttpTimeoutsTests {
                         .withHeader("Content-Type", "application/json")
                         .withFixedDelay(1)));
 
-        var client = new HttpHandler(API_KEY, Duration.ofMillis(10));
+        var client = new HttpHandler(API_KEY, APP_UUID, Duration.ofMillis(10));
         assertThrows(HttpTimeoutException.class, () -> client.getCagePublicKeyFromEndpoint(wireMockRuntimeInfo.getHttpBaseUrl() + endpoint));
     }
 
@@ -40,7 +41,7 @@ public class WhenDealingWithHttpTimeoutsTests {
                         .withHeader("Content-Type", "application/json")
                         .withFixedDelay(1)));
 
-        var client = new HttpHandler(API_KEY, Duration.ofMillis(10));
+        var client = new HttpHandler(API_KEY, APP_UUID, Duration.ofMillis(10));
 
         assertThrows(HttpTimeoutException.class, () -> client.runCage(wireMockRuntimeInfo.getHttpBaseUrl(), "Foo", "Foo", true, null));
     }

--- a/lib/src/test/java/com/evervault/WhenEncryptingDifferentTypesOfDataTests.java
+++ b/lib/src/test/java/com/evervault/WhenEncryptingDifferentTypesOfDataTests.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
@@ -86,8 +87,8 @@ public class WhenEncryptingDifferentTypesOfDataTests {
     void handlesBooleanCorrectly() throws NotImplementedException, InvalidAlgorithmParameterException, NoSuchAlgorithmException, InvalidKeyException, NotPossibleToHandleDataTypeException, IOException, InvalidCipherException {
         var testSetup = getService();
 
-        when(testSetup.encryptionProvider.encryptData(eq(DataHeader.Boolean), any(), eq(new byte[]{1}), any(), any())).thenReturn("true");
-        when(testSetup.encryptionProvider.encryptData(eq(DataHeader.Boolean), any(), eq(new byte[]{0}), any(), any())).thenReturn("false");
+        when(testSetup.encryptionProvider.encryptData(eq(DataHeader.Boolean), any(), eq("true".getBytes(StandardCharsets.UTF_8)), any(), any())).thenReturn("true");
+        when(testSetup.encryptionProvider.encryptData(eq(DataHeader.Boolean), any(), eq("false".getBytes(StandardCharsets.UTF_8)), any(), any())).thenReturn("false");
 
         assert "true".equals(testSetup.encryptionService.encrypt(true));
         assert "false".equals(testSetup.encryptionService.encrypt(false));

--- a/lib/src/test/java/com/evervault/WhenPerformingHttpRequestTests.java
+++ b/lib/src/test/java/com/evervault/WhenPerformingHttpRequestTests.java
@@ -7,6 +7,8 @@ import com.evervault.services.HttpHandler;
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import com.google.gson.internal.LinkedTreeMap;
+
+import org.eclipse.jetty.util.IO;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -24,7 +26,21 @@ public class WhenPerformingHttpRequestTests {
     private static final String USER_AGENT_HEADER = "evervault-java/1.0";
     private static final String CONTENT_TYPE = "application/json";
     private static final String API_KEY = "Foo";
+    private static final String APP_UUID = "Bar";
     private static final String RAW_TEXT_CAGES_KEY_ENDPOINT = "{\"teamUuid\":\"de7350990fd7\",\"key\":\"MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAo7+jkmJ1uZsmiA5omE96RaepPYj2J6DzlE0DNWPoVZZNVb/ShqxSA4zKfE9Kh4MuI6fKpg0/pMhf8Re398ac9s2xKsjDvQHOhLLOfmgcrQgZyLGvdsrllcb1JY8kLNTdgONpn3S/BQetdEPG7oFp1RRIw60Iyy+v2R+r092zItbqLUpb0Vpu2z2uMxylZFc33VuDVIFF+fc9vE0gVPFoHezZ+1+EmqiJdkH/1GcPoVswzCvg3djmCo3Zhx3GdiB464GOl2ZlujwSN9dPkFhndIUZYK9iJhlcItyGkKH1OV/HAl8k2u/7pKUDLFe4lMWX9yASuj6y3CLdrPcbAuky3QIDAQAB\",\"ecdhKey\":\"AhmiyfX6dVt1IML5qF+giWEdCaX60oQE+d9b2FXOSOXr\"}";
+
+    protected class CardData {
+        String cardNumber;
+        int cvv;
+        String expiry; 
+    }
+
+    protected class SomeClass {
+        String foo;
+        String bar;
+        String baz;
+    }
+
 
     private void assertHeadersForCageKey(String endpoint, String apiKey, HashMap<String, String> headerMap) {
         var pattern = getRequestedFor(urlEqualTo(endpoint))
@@ -64,7 +80,7 @@ public class WhenPerformingHttpRequestTests {
                         .withHeader("Content-Type", "application/json")
                         .withBody(RAW_TEXT_CAGES_KEY_ENDPOINT)));
 
-        var client = new HttpHandler(API_KEY);
+        var client = new HttpHandler(API_KEY, APP_UUID);
 
         client.getCagePublicKeyFromEndpoint(wireMockRuntimeInfo.getHttpBaseUrl() + "/");
     }
@@ -72,7 +88,7 @@ public class WhenPerformingHttpRequestTests {
     @Test
     public void runCageUrlEndingWithSlashDoesNotThrow(WireMockRuntimeInfo wireMockRuntimeInfo) throws HttpFailureException, IOException, InterruptedException {
         final String cageNameEndpoint = "/test-cage";
-        var client = new HttpHandler(API_KEY);
+        var client = new HttpHandler(API_KEY, APP_UUID);
 
         stubFor(post(urlEqualTo(cageNameEndpoint)).willReturn(aResponse()
                 .withHeader("Content-Type", "application/json")
@@ -94,7 +110,7 @@ public class WhenPerformingHttpRequestTests {
                         .withHeader("Content-Type", "application/json")
                         .withBody(RAW_TEXT_CAGES_KEY_ENDPOINT)));
 
-        var client = new HttpHandler(API_KEY);
+        var client = new HttpHandler(API_KEY, APP_UUID);
 
         client.getCagePublicKeyFromEndpoint(wireMockRuntimeInfo.getHttpBaseUrl());
 
@@ -110,7 +126,7 @@ public class WhenPerformingHttpRequestTests {
                         .withHeader("Content-Type", "application/json")
                         .withBody(RAW_TEXT_CAGES_KEY_ENDPOINT)));
 
-        var client = new HttpHandler(API_KEY);
+        var client = new HttpHandler(API_KEY, APP_UUID);
 
         var headerMap = new HashMap<String, String>();
         headerMap.put("Foo", "Bar");
@@ -123,7 +139,7 @@ public class WhenPerformingHttpRequestTests {
 
     @Test
     void hittingCagePublicKeyEndpointParsesItCorrectly(WireMockRuntimeInfo wireMockRuntimeInfo) throws IOException, InterruptedException, HttpFailureException {
-        var client = new HttpHandler(API_KEY);
+        var client = new HttpHandler(API_KEY, APP_UUID);
         final var urlPath = "/cages/key";
 
         stubFor(get(urlEqualTo(urlPath))
@@ -140,7 +156,7 @@ public class WhenPerformingHttpRequestTests {
 
     @Test
     void httpStatusNotOkMustThrow(WireMockRuntimeInfo wireMockRuntimeInfo) {
-        var client = new HttpHandler(API_KEY);
+        var client = new HttpHandler(API_KEY, APP_UUID);
         final var urlPath = wireMockRuntimeInfo.getHttpBaseUrl() + "/cages/key";
 
         assertThrows(HttpFailureException.class, () -> client.getCagePublicKeyFromEndpoint(urlPath));
@@ -153,7 +169,7 @@ public class WhenPerformingHttpRequestTests {
     @Test
     void hittingCageRunEndpointValidatesBasicHeaders(WireMockRuntimeInfo wireMockRuntimeInfo) throws HttpFailureException, IOException, InterruptedException {
         final String cageNameEndpoint = "/test-cage";
-        var client = new HttpHandler(API_KEY);
+        var client = new HttpHandler(API_KEY, APP_UUID);
 
         stubFor(post(urlEqualTo(cageNameEndpoint)).willReturn(aResponse()
                 .withHeader("Content-Type", "application/json")
@@ -171,7 +187,7 @@ public class WhenPerformingHttpRequestTests {
     @Test
     void hittingCageRunEndpointWorksCorrectly(WireMockRuntimeInfo wireMockRuntimeInfo) throws HttpFailureException, IOException, InterruptedException {
         final String cageName = "/test-cage";
-        var client = new HttpHandler(API_KEY);
+        var client = new HttpHandler(API_KEY, APP_UUID);
 
         stubFor(post(urlEqualTo(cageName)).willReturn(aResponse()
                 .withHeader("Content-Type", "application/json")
@@ -192,7 +208,7 @@ public class WhenPerformingHttpRequestTests {
 
     @Test
     void hittingCageRunEndpointThrows(WireMockRuntimeInfo wireMockRuntimeInfo) {
-        var client = new HttpHandler(API_KEY);
+        var client = new HttpHandler(API_KEY, APP_UUID);
 
         var data = new SomeData();
         data.name = "test";
@@ -203,7 +219,7 @@ public class WhenPerformingHttpRequestTests {
     @Test
     void validatesAsyncTrueHeaderWhenHittingCageRunEndpoint(WireMockRuntimeInfo wireMockRuntimeInfo) throws HttpFailureException, IOException, InterruptedException {
         final String cageNameEndpoint = "/test-cage";
-        var client = new HttpHandler(API_KEY);
+        var client = new HttpHandler(API_KEY, APP_UUID);
 
         stubFor(post(urlEqualTo(cageNameEndpoint)).willReturn(aResponse()
                 .withHeader("Content-Type", "application/json")
@@ -225,7 +241,7 @@ public class WhenPerformingHttpRequestTests {
     @Test
     void validatesAsyncFalseHeaderWhenHittingCageRunEndpoint(WireMockRuntimeInfo wireMockRuntimeInfo) throws HttpFailureException, IOException, InterruptedException {
         final String cageNameEndpoint = "/test-cage";
-        var client = new HttpHandler(API_KEY);
+        var client = new HttpHandler(API_KEY, APP_UUID);
 
         stubFor(post(urlEqualTo(cageNameEndpoint)).willReturn(aResponse()
                 .withHeader("Content-Type", "application/json")
@@ -247,7 +263,7 @@ public class WhenPerformingHttpRequestTests {
     @Test
     void asyncHeaderIsIgnoredWhenVersionIsEmpty(WireMockRuntimeInfo wireMockRuntimeInfo) throws HttpFailureException, IOException, InterruptedException {
         final String cageNameEndpoint = "/test-cage";
-        var client = new HttpHandler(API_KEY);
+        var client = new HttpHandler(API_KEY, APP_UUID);
 
         stubFor(post(urlEqualTo(cageNameEndpoint)).willReturn(aResponse()
                 .withHeader("Content-Type", "application/json")
@@ -269,7 +285,7 @@ public class WhenPerformingHttpRequestTests {
     @Test
     void hittingCreateRunTokenEndpointValidatesBasicHeaders(WireMockRuntimeInfo wireMockRuntimeInfo) throws HttpFailureException, IOException, InterruptedException {
         final String createRunTokenEndpoint = "/v2/functions/test-cage/run-token";
-        var client = new HttpHandler(API_KEY);
+        var client = new HttpHandler(API_KEY, APP_UUID);
 
         stubFor(post(urlEqualTo(createRunTokenEndpoint)).willReturn(aResponse()
                 .withHeader("Content-Type", "application/json")
@@ -287,7 +303,7 @@ public class WhenPerformingHttpRequestTests {
     @Test
     void hittingCreateRunTokenEndpointWorksCorrectly(WireMockRuntimeInfo wireMockRuntimeInfo) throws HttpFailureException, IOException, InterruptedException {
         final String createRunTokenEndpoint = "/v2/functions/test-cage/run-token";
-        var client = new HttpHandler(API_KEY);
+        var client = new HttpHandler(API_KEY, APP_UUID);
 
         stubFor(post(urlEqualTo(createRunTokenEndpoint)).willReturn(aResponse()
                 .withHeader("Content-Type", "application/json")
@@ -304,7 +320,7 @@ public class WhenPerformingHttpRequestTests {
 
     @Test
     void hittingRunTokenEndpointThrows(WireMockRuntimeInfo wireMockRuntimeInfo) {
-        var client = new HttpHandler(API_KEY);
+        var client = new HttpHandler(API_KEY, APP_UUID);
 
         var data = new SomeData();
         data.name = "test";
@@ -313,9 +329,34 @@ public class WhenPerformingHttpRequestTests {
     }
 
     @Test
+    void hittingDecryptEndpointWorksCorrectly(WireMockRuntimeInfo wireMockRuntimeInfo) throws HttpFailureException, IOException, InterruptedException {
+        var expectedDecryptResult = new CardData();
+        expectedDecryptResult.cardNumber = "4242424242424242";
+        expectedDecryptResult.cvv = 123;
+        expectedDecryptResult.expiry = "12/24";
+
+        final String decryptEndpoint = "/decrypt";
+        var client = new HttpHandler(APP_UUID, API_KEY);
+        stubFor(post(urlEqualTo(decryptEndpoint)).willReturn(aResponse()
+                .withHeader("Content-Type", "application/json")
+                .withBody("{\"cardNumber\": \"4242424242424242\", \"cvv\": \"123\", \"expiry\": \"12/24\"}")
+                .withStatus(200)));
+        
+        var dataToDecrypt = new HashMap<String, String>();
+        dataToDecrypt.put("cardNumber", "ev:abc123:$");
+        dataToDecrypt.put("cvv", "ev:def456:$");
+        dataToDecrypt.put("expiry", "12/24");
+
+        CardData result = client.decrypt(wireMockRuntimeInfo.getHttpBaseUrl(), dataToDecrypt, CardData.class);
+        Assertions.assertEquals(result.cardNumber, expectedDecryptResult.cardNumber);
+        Assertions.assertEquals(result.cvv, expectedDecryptResult.cvv);
+        Assertions.assertEquals(result.expiry, expectedDecryptResult.expiry);
+    }
+
+    @Test
     void hittingGetOutboundRelayConfigurationEndpointWorksCorrectly(WireMockRuntimeInfo wireMockRuntimeInfo) throws HttpFailureException, IOException, InterruptedException {
         final String getRelayOutboundConfigEndpoint = "/v2/relay-outbound";
-        var client = new HttpHandler(API_KEY);
+        var client = new HttpHandler(API_KEY, APP_UUID);
 
         stubFor(get(urlEqualTo(getRelayOutboundConfigEndpoint)).willReturn(aResponse()
                 .withHeader("Content-Type", "application/json")
@@ -336,7 +377,7 @@ public class WhenPerformingHttpRequestTests {
     @Test
     void hittingGetOutboundRelayConfigurationEndpointWorksCorrectlyWhenNoDestinationDomainIsSet(WireMockRuntimeInfo wireMockRuntimeInfo) throws HttpFailureException, IOException, InterruptedException {
         final String getRelayOutboundConfigEndpoint = "/v2/relay-outbound";
-        var client = new HttpHandler(API_KEY);
+        var client = new HttpHandler(API_KEY, APP_UUID);
 
         stubFor(get(urlEqualTo(getRelayOutboundConfigEndpoint)).willReturn(aResponse()
                 .withHeader("Content-Type", "application/json")
@@ -354,7 +395,7 @@ public class WhenPerformingHttpRequestTests {
     @Test
     void hittingGetOutboundRelayConfigurationEndpointWorksCorrectlyWhenThePollIntervalResponseHeaderIsSet(WireMockRuntimeInfo wireMockRuntimeInfo) throws HttpFailureException, IOException, InterruptedException {
         final String getRelayOutboundConfigEndpoint = "/v2/relay-outbound";
-        var client = new HttpHandler(API_KEY);
+        var client = new HttpHandler(API_KEY, APP_UUID);
 
         stubFor(get(urlEqualTo(getRelayOutboundConfigEndpoint)).willReturn(aResponse()
                 .withHeader("Content-Type", "application/json")
@@ -375,7 +416,7 @@ public class WhenPerformingHttpRequestTests {
     @Test
     void hittingGetOutboundRelayConfigurationEndpointDoesNotThrowWhenThePollIntervalResponseHeaderIsInvalid(WireMockRuntimeInfo wireMockRuntimeInfo) throws HttpFailureException, IOException, InterruptedException {
         final String getRelayOutboundConfigEndpoint = "/v2/relay-outbound";
-        var client = new HttpHandler(API_KEY);
+        var client = new HttpHandler(API_KEY, APP_UUID);
 
         stubFor(get(urlEqualTo(getRelayOutboundConfigEndpoint)).willReturn(aResponse()
                 .withHeader("Content-Type", "application/json")
@@ -396,7 +437,7 @@ public class WhenPerformingHttpRequestTests {
     @Test
     void hittingGetOutboundRelayConfigurationEndpointDoesNotThrowWhenThePollIntervalResponseHeaderIsNotSet(WireMockRuntimeInfo wireMockRuntimeInfo) throws HttpFailureException, IOException, InterruptedException {
         final String getRelayOutboundConfigEndpoint = "/v2/relay-outbound";
-        var client = new HttpHandler(API_KEY);
+        var client = new HttpHandler(API_KEY, APP_UUID);
 
         stubFor(get(urlEqualTo(getRelayOutboundConfigEndpoint)).willReturn(aResponse()
                 .withHeader("Content-Type", "application/json")
@@ -417,7 +458,7 @@ public class WhenPerformingHttpRequestTests {
     @Test
     void hittingGetOutboundRelayConfigurationEndpointThrows(WireMockRuntimeInfo wireMockRuntimeInfo) {
         final String getRelayOutboundConfigEndpoint = "/v2/relay-outbound";
-        var client = new HttpHandler(API_KEY);
+        var client = new HttpHandler(API_KEY, APP_UUID);
 
         stubFor(get(urlEqualTo(getRelayOutboundConfigEndpoint)).willReturn(aResponse()
                 .withStatus(500)));

--- a/lib/src/test/java/com/evervault/WhenUsingApisDecrypt.java
+++ b/lib/src/test/java/com/evervault/WhenUsingApisDecrypt.java
@@ -1,0 +1,102 @@
+package com.evervault;
+
+import java.io.IOException;
+import java.util.HashMap;
+
+import com.evervault.contracts.IExecute;
+import com.evervault.contracts.IProvideCircuitBreaker;
+import com.evervault.contracts.IProvideDecrypt;
+import com.evervault.exceptions.EvervaultException;
+import com.evervault.exceptions.HttpFailureException;
+import com.evervault.exceptions.NotPossibleToHandleDataTypeException;
+import com.evervault.services.EvervaultService;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class WhenUsingApisDecrypt {
+    private final IProvideDecrypt decryptProvider;
+    private final Evervault evervaultService;
+    private final IProvideCircuitBreaker circuitBreakerProvider;
+
+    private static class Evervault extends EvervaultService {
+        public void setupWrapper(IProvideDecrypt decryptProvider, IProvideCircuitBreaker circuitBreakerProvider) {
+            this.setupCircuitBreaker(circuitBreakerProvider);
+            this.setupDecryptProvider(decryptProvider);
+        }
+    }
+
+    protected class CardData {
+        String cardNumber;
+        int cvv;
+        String expiry; 
+    }
+
+    protected class SomeClass {
+        String foo;
+        String bar;
+        String baz;
+    }
+
+    private static class CircuitBreakerInternal implements IProvideCircuitBreaker {
+        @Override
+        public <TReturn> TReturn execute(int methodIdentifier, IExecute<TReturn> executable) throws NotPossibleToHandleDataTypeException, HttpFailureException, IOException, InterruptedException {
+            return executable.execute();
+        }
+    }
+
+    public WhenUsingApisDecrypt() {
+        decryptProvider = mock(IProvideDecrypt.class);
+        circuitBreakerProvider = new CircuitBreakerInternal();
+        evervaultService = new Evervault();
+    }
+
+    @Test
+    void callingToDecryptReturnsTheHttpContent() throws HttpFailureException, IOException, InterruptedException, EvervaultException {
+        var decryptResult = new CardData();
+        decryptResult.cardNumber = "4242424242424242";
+        decryptResult.cvv = 123;
+        decryptResult.expiry = "12/24";
+
+        var dataToDecrypt = new HashMap<String, String>();
+        dataToDecrypt.put("cardNumber", "ev:abc123:$");
+        dataToDecrypt.put("cvv", "ev:def456:$");
+        dataToDecrypt.put("expiry", "12/24");
+
+        when(decryptProvider.decrypt(anyString(), any(), any())).thenReturn(decryptResult);
+
+        evervaultService.setupWrapper(decryptProvider, circuitBreakerProvider);
+        
+        var result = evervaultService.decrypt(dataToDecrypt, CardData.class);
+
+        assert decryptResult.equals(result);
+    }
+
+    @Test
+    void nullParameterThrows() throws HttpFailureException, IOException, InterruptedException, EvervaultException {
+        var decryptResult = new CardData();
+        decryptResult.cardNumber = "4242424242424242";
+        decryptResult.cvv = 123;
+        decryptResult.expiry = "12/24";
+
+        var dataToDecrypt = new HashMap<String, String>();
+        dataToDecrypt.put("cardNumber", "ev:abc123:$");
+        dataToDecrypt.put("cvv", "ev:def456:$");
+        dataToDecrypt.put("expiry", "12/24");
+
+        when(decryptProvider.decrypt(anyString(), any(), any())).thenReturn(decryptResult);
+
+        evervaultService.setupWrapper(decryptProvider, circuitBreakerProvider);
+
+        assertThrows(EvervaultException.class, () -> evervaultService.decrypt(null, CardData.class));
+        assertThrows(EvervaultException.class, () -> evervaultService.decrypt(dataToDecrypt, null));
+    }
+
+    @Test
+    void providerNotSetThrows() {
+        assertThrows(NullPointerException.class, () -> evervaultService.setupWrapper(null, circuitBreakerProvider));
+    }
+}


### PR DESCRIPTION
BREAKING CHANGE: The UUID of the App is now required when initialising the SDK

# Why
- Add `decrypt()` function
- Require `appUuid` (the App ID) when initialising the SDK

# How
- Provide a decrypt function that takes a `HashMap` containing encrypted data and allows users to decrypt and deserialise the decrypted data to a specified type.
- Require the user to pass the `appUuid` when initialising the SDK to allow for new Auth method.

### Commit Messages

We use [semantic-release](https://github.com/semantic-release/semantic-release#how-does-it-work) for deployments. If one of your commits should be deployed, ensure the commit message is in the format corresponding to the correct release type. This can also be done in a squash commit.

Note: breaking changes should always use the `BREAKING CHANGE:` commit message format.
BREAKING CHANGE: The UUID of the App is now required when initialising the SDK