### PR TITLE
Fix outbound destination matching logic

### DIFF
--- a/lib/src/main/java/com/evervault/contracts/IProvideDecryptionAndIgnoreDomains.java
+++ b/lib/src/main/java/com/evervault/contracts/IProvideDecryptionAndIgnoreDomains.java
@@ -1,6 +1,10 @@
 package com.evervault.contracts;
 
+import java.util.regex.Pattern;
+
 public interface IProvideDecryptionAndIgnoreDomains {
     public String[] getAlwaysIgnoreDomains();
+    public Pattern[] getAlwaysIgnoreDomainRegexes();
     public String[] getDecryptionDomains();
+    public Pattern[] getDecryptionDomainRegexes();
 }

--- a/lib/src/main/java/com/evervault/services/StaticOutboundRelayConfigService.java
+++ b/lib/src/main/java/com/evervault/services/StaticOutboundRelayConfigService.java
@@ -1,21 +1,39 @@
 package com.evervault.services;
 
 import com.evervault.contracts.IProvideDecryptionAndIgnoreDomains;
+import com.evervault.utils.DomainRegexHandler;
+
+import java.util.Arrays;
+import java.util.regex.Pattern;
 
 public class StaticOutboundRelayConfigService implements IProvideDecryptionAndIgnoreDomains {
     private String[] alwaysIgnoreDomains;
+    private Pattern[] alwaysIgnoreDomainRegexes;
     private String[] decryptionDomains;
+    private Pattern[] decryptionDomainRegexes;
 
     public StaticOutboundRelayConfigService(String[] alwaysIgnoreDomains, String[] decryptionDomains) {
         this.alwaysIgnoreDomains = alwaysIgnoreDomains;
+        this.alwaysIgnoreDomainRegexes = DomainRegexHandler
+            .buildDomainRegexesFromPatterns(alwaysIgnoreDomains);
         this.decryptionDomains = decryptionDomains;
+        this.decryptionDomainRegexes = DomainRegexHandler
+            .buildDomainRegexesFromPatterns(decryptionDomains);
     }
 
     public String[] getAlwaysIgnoreDomains() {
         return alwaysIgnoreDomains;
     }
 
+    public Pattern[] getAlwaysIgnoreDomainRegexes() {
+        return alwaysIgnoreDomainRegexes;
+    }
+
     public String[] getDecryptionDomains() {
         return decryptionDomains;
+    }
+
+    public Pattern[] getDecryptionDomainRegexes() {
+        return decryptionDomainRegexes;
     }
 }

--- a/lib/src/main/java/com/evervault/utils/DomainRegexHandler.java
+++ b/lib/src/main/java/com/evervault/utils/DomainRegexHandler.java
@@ -1,0 +1,27 @@
+package com.evervault.utils;
+
+import java.util.regex.Pattern;
+import java.util.Arrays;
+
+public class DomainRegexHandler {
+    private final static Pattern GLOBSTAR_PATTERN = Pattern.compile("(?<!\\*)\\*\\*+\\.");
+    private final static Pattern DOT_PATTERN = Pattern.compile("\\.");
+    private final static Pattern STAR_PATTERN = Pattern.compile("(?<!\\*)\\*+");
+
+    private final static Pattern SUBDOMAIN_PATTERN = Pattern.compile("(\\.\\*)([^\\\\*.])");
+
+    public static String buildDomainRegexFromPattern(String pattern) {
+        pattern = GLOBSTAR_PATTERN.matcher(pattern).replaceAll("*");
+        pattern = DOT_PATTERN.matcher(pattern).replaceAll("\\\\.");
+        pattern = STAR_PATTERN.matcher(pattern).replaceAll(".*");
+        pattern = SUBDOMAIN_PATTERN.matcher(pattern).replaceAll("$1(^|\\\\.)$2");
+        return String.format("^%s$", pattern);
+    }
+
+    public static Pattern[] buildDomainRegexesFromPatterns(String[] patterns) {
+        return Arrays.stream(patterns)
+            .map(DomainRegexHandler::buildDomainRegexFromPattern)
+            .map(pattern -> Pattern.compile(pattern, Pattern.CASE_INSENSITIVE))
+            .toArray(Pattern[]::new);
+    }
+}


### PR DESCRIPTION
# Why

Domain matching logic was being done case sensitively and in a manner different to how it is described in the UI.

# How

Generate regexes that match as described in the UI, ignoring case. This change is backwards compatible and can be seen as an extension as well as a fix as the previously implemented version only handled a special case.

### Commit Messages

We use [semantic-release](https://github.com/semantic-release/semantic-release#how-does-it-work) for deployments. If one of your commits should be deployed, ensure the commit message is in the format corresponding to the correct release type. This can also be done in a squash commit.

Note: breaking changes should always use the `BREAKING CHANGE:` commit message format.
