### PR TITLE
fix: Fix encryption of Serializable

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ implementation 'com.evervault:lib:3.3.1'
 <dependency>
   <groupId>com.evervault</groupId>
   <artifactId>lib</artifactId>
-  <version>3.3.1</version>
+  <version>4.0.1</version>
 </dependency>
 ```
 

--- a/lib/src/main/java/com/evervault/dataHandlers/SerializableHandler.java
+++ b/lib/src/main/java/com/evervault/dataHandlers/SerializableHandler.java
@@ -23,6 +23,7 @@ public class SerializableHandler implements IDataHandler {
         this.encryptionProvider = encryptionProvider;
         this.generatedEcdhKey = generatedEcdhKey;
         this.sharedKey = sharedKey;
+        this.teamPublicKey = teamPublicKey;
     }
 
     @Override


### PR DESCRIPTION
# Why
Can't encrypt serializable because the handler doesn't store the team's public key

# How

Give the handler the public key

### Commit Messages

We use [semantic-release](https://github.com/semantic-release/semantic-release#how-does-it-work) for deployments. If one of your commits should be deployed, ensure the commit message is in the format corresponding to the correct release type. This can also be done in a squash commit.

Note: breaking changes should always use the `BREAKING CHANGE:` commit message format.
