### PR TITLE
Update build.gradle version programmatically

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,7 @@ jobs:
         with:
           title: 'New Release'
           commit: 'Release new version'
+          version: npm run version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "evervault-java",
     "private": true,
-    "version": "3.3.2",
+    "version": "4.1.0",
     "scripts": {
         "version": "changeset version && PACKAGE_VERSION=$(node -p \"require('./package.json').version\") && sed -i \"s/version '.*'/version '$PACKAGE_VERSION'/g\" lib/build.gradle"
     },


### PR DESCRIPTION
# Why
We need to run a custom script when the release PR is created/updated to update the `build.gradle` file with the new version number.

# How
Run `npm run version` when the changelog file is generated