### PR TITLE
Update release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
                   print;
               }
             ' CHANGELOG.md)
-            gh release create v$COMMIT_TAG -t "v$COMMIT_TAG" -n "$CHANGELOG"
+            gh release create $COMMIT_TAG -t "$COMMIT_TAG" -n "$CHANGELOG"
             ./generate_gradle_properties.bash ${{ github.workspace }}
             ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
           else


### PR DESCRIPTION
# Why
Our release workflow prepends the release name and the release tag with a `v` leading versions to be named `vv[version number]`.

# How
Removes unnecessary `v` in the release workflow