### PR TITLE
ci: accept main as well as master in workflow triggers

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,10 +13,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "master" ]
+    branches: ["master", "main"]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ "master" ]
+    branches: ["master", "main"]
   schedule:
     - cron: '24 6 * * 6'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - main
 
 jobs:
   changesets:


### PR DESCRIPTION
Preflight for the org-wide default branch rename to `main`.

Workflow triggers now match both `master` and `main`, so nothing stops
firing during the rename. The `master` entries are removed in the follow-up
cleanup PR after the default branch has been flipped.