### PR TITLE
chore: set Dependabot update intervals to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "gradle"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     open-pull-requests-limit: 10
     groups:
       gradle-minor-and-patch:
@@ -13,4 +13,4 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"


### PR DESCRIPTION
# Why
Reduce Dependabot noise by moving all update schedules from weekly to monthly.

# How
Changed the `interval:` value for both entries in `.github/dependabot.yml` (`gradle` and `github-actions` ecosystems) from `"weekly"` to `"monthly"`. No other config changed.

## Ecosystem check
- `gradle` (directory `/`): correct — build system is Gradle (`build.gradle`, `settings.gradle`, `lib/build.gradle`, `gradlew`), and the root directory holds the top-level manifest.
- `github-actions` (directory `/`): correct — `.github/workflows/codeql.yml`, `release.yml`, `sdk.yml` are present.
- No `Dockerfile` in the repo — nothing to add there.
- A root `package.json` exists but is unconfigured in Dependabot. It's a private, non-published package used only to drive the Changesets release tooling (`devDependencies: @changesets/cli`), not an app dependency tree — flagging for awareness, no change made per instructions.
